### PR TITLE
Use inherited JDK from project

### DIFF
--- a/intellij-plugin-v4.iml
+++ b/intellij-plugin-v4.iml
@@ -10,7 +10,7 @@
       <sourceFolder url="file://$MODULE_DIR$/resources/templates" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/gen/antlr4" isTestSource="false" />
     </content>
-    <orderEntry type="jdk" jdkName="IDEA IC-123.SNAPSHOT" jdkType="IDEA JDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library">
       <library>


### PR DESCRIPTION
Only specify the JDK (i.e. reference version of IntelliJ) in one place - the project. Modules then inherit this setting rather than duplicate it.
