### PR TITLE
Send ERRCHAR token to parser for unrecognized char. Also make WS go to p...

### DIFF
--- a/src/grammars/org/antlr/intellij/plugin/parser/ANTLRv4Lexer.g4
+++ b/src/grammars/org/antlr/intellij/plugin/parser/ANTLRv4Lexer.g4
@@ -213,7 +213,7 @@ UNICODE_ESC
 fragment
 HEX_DIGIT : [0-9a-fA-F]	;
 
-WS  :	[ \t\r\n\f]+ ; //-> channel(HIDDEN)	;
+WS  :	[ \t\r\n\f]+ -> channel(HIDDEN)	;
 
 // -----------------
 // Illegal Character
@@ -226,11 +226,9 @@ WS  :	[ \t\r\n\f]+ ; //-> channel(HIDDEN)	;
 // but we will not try to analyse or code generate from a file with lexical
 // errors.
 //
-/*
 ERRCHAR
 	:	.	-> channel(HIDDEN)
 	;
-*/
 
 mode ArgAction; // E.g., [int x, List<String> a[]]
 


### PR DESCRIPTION
...arser on hidden channel not real token so we can reuse grammar outside of intellij.
