### PR TITLE
If package is not configured for the grammar file, get it from relative path

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -52,3 +52,4 @@ YYYY/MM/DD, github id, Full name, email
 2014/01/30, sharwell, Sam Harwell, sam@tunnelvisionlabs.com
 2014/04/04, migulorama, Miguel Marques, migulorama@gmail.com
 2014/04/21, mhordecki, Mike Hordecki, mike@hordecki.com
+2014/12/22, ponomandr, Andrey Ponomarev, ponomandr@gmail.com

--- a/src/java/org/antlr/intellij/plugin/parsing/RunANTLROnGrammarFile.java
+++ b/src/java/org/antlr/intellij/plugin/parsing/RunANTLROnGrammarFile.java
@@ -1,5 +1,6 @@
 package org.antlr.intellij.plugin.parsing;
 
+import com.google.common.base.Strings;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.notification.Notification;
@@ -9,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.antlr.intellij.plugin.ANTLRv4PluginController;
 import org.antlr.intellij.plugin.configdialogs.ConfigANTLRPerGrammar;
@@ -159,6 +161,12 @@ public class RunANTLROnGrammarFile extends Task.Modal {
 		String sourcePath = ConfigANTLRPerGrammar.getParentDir(vfile);
 
 		String package_ = ConfigANTLRPerGrammar.getProp(project, qualFileName, ConfigANTLRPerGrammar.PROP_PACKAGE, MISSING);
+		if ( package_==MISSING) {
+			package_ = ProjectRootManager.getInstance(project).getFileIndex().getPackageNameByDirectory(vfile.getParent());
+			if (Strings.isNullOrEmpty(package_)) {
+				package_ = MISSING;
+			}
+		}
 		if ( package_!=MISSING) {
 			args.put("-package", package_);
 		}


### PR DESCRIPTION
I believe antlr4-maven-plugin does something similar.