### PR TITLE
folding improvements

### DIFF
--- a/intellij-plugin-v4.iml
+++ b/intellij-plugin-v4.iml
@@ -16,6 +16,8 @@
       <sourceFolder url="file://$MODULE_DIR$/src/adaptor" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/resources/liveTemplates" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test/testData" type="java-resource" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/src/java/org/antlr/intellij/plugin/ANTLRv4FileRoot.java
+++ b/src/java/org/antlr/intellij/plugin/ANTLRv4FileRoot.java
@@ -4,6 +4,8 @@ import com.intellij.extapi.psi.PsiFileBase;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.antlr.intellij.plugin.psi.GrammarSpecNode;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -34,4 +36,8 @@ public class ANTLRv4FileRoot extends PsiFileBase {
 	public PsiElement[] getChildren() {
 		return super.getChildren();
 	}
+
+    public GrammarSpecNode getGrammarSpec(){
+        return PsiTreeUtil.getChildOfType(this, GrammarSpecNode.class);
+    }
 }

--- a/src/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilder.java
+++ b/src/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilder.java
@@ -50,7 +50,7 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
     private static final TokenElementType RBRACE = ANTLRv4TokenTypes.getTokenElementType(ANTLRv4Lexer.RBRACE);
     private static final TokenElementType SEMICOLON = ANTLRv4TokenTypes.getTokenElementType(ANTLRv4Lexer.SEMI);
 
-    private static final RuleElementType RULESPEC = ANTLRv4TokenTypes.getRuleElementType(ANTLRv4Parser.RULE_ruleSpec);
+    //private static final RuleElementType RULESPEC = ANTLRv4TokenTypes.getRuleElementType(ANTLRv4Parser.RULE_ruleSpec);
 
     private static final TokenSet RULE_BLOCKS = TokenSet.create(
             ANTLRv4TokenTypes.getRuleElementType(ANTLRv4Parser.RULE_lexerBlock),
@@ -75,13 +75,13 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
 
         addActionFoldingDescriptors(descriptors, grammarSpec);
 
-        addCommentDescriptors(descriptors, grammarSpec, document);
+        addCommentDescriptors(descriptors, grammarSpec);
 
         addOptionsFoldingDescriptor(descriptors, grammarSpec);
 
         addTokensFoldingDescriptor(descriptors, grammarSpec);
 
-        //todo make lexer modes foldable.
+        //todo make lexer modes foldable. (?)
 
 
     }
@@ -149,8 +149,8 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
                 if (nextRange == TextRange.EMPTY_RANGE) break;
 
                 if (lastLine + 1 == document.getLineNumber(candidate.getTextRange().getStartOffset())) {
-                    rulesInGroup.add(candidate);
-                    candidate = iterator.next(); //pop from iterator
+                    rulesInGroup.add(iterator.next());//consume next
+
                     endOfs = nextRange.getEndOffset();
                     lastLine = document.getLineNumber(endOfs);
                     count++;
@@ -185,6 +185,7 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
     }
 
 
+    @SuppressWarnings("unchecked")
     private static TextRange rangeForRule(RuleSpecNode specNode) {
         GrammarElementRefNode refNode = PsiTreeUtil.findChildOfAnyType(specNode, GrammarElementRefNode.class);
         if (refNode == null) return TextRange.EMPTY_RANGE;
@@ -261,7 +262,7 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
 
     }
 
-    private static void addCommentDescriptors(List<FoldingDescriptor> descriptors, PsiElement root, Document document) {
+    private static void addCommentDescriptors(List<FoldingDescriptor> descriptors, PsiElement root) {
         Set<PsiElement> processedComments = new HashSet<PsiElement>();
         for (PsiElement comment : MyPsiUtils.findChildrenOfType(root, ANTLRv4TokenTypes.COMMENTS)) {
             IElementType type = comment.getNode().getElementType();

--- a/src/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilder.java
+++ b/src/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilder.java
@@ -341,7 +341,7 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
         if (element.getNode().getElementType() == LINE_COMMENT_TOKEN) {
             return "//...";
         } else if (element instanceof RuleSpecNode) {
-            return ":...";
+            return ":...;";
         } else if (element instanceof AtAction) {
             return "{...}";
         }

--- a/src/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilder.java
+++ b/src/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilder.java
@@ -20,10 +20,7 @@ import org.antlr.intellij.adaptor.lexer.TokenElementType;
 import org.antlr.intellij.plugin.ANTLRv4FileRoot;
 import org.antlr.intellij.plugin.parser.ANTLRv4Lexer;
 import org.antlr.intellij.plugin.parser.ANTLRv4Parser;
-import org.antlr.intellij.plugin.psi.AtAction;
-import org.antlr.intellij.plugin.psi.GrammarElementRefNode;
-import org.antlr.intellij.plugin.psi.GrammarSpecNode;
-import org.antlr.intellij.plugin.psi.RuleSpecNode;
+import org.antlr.intellij.plugin.psi.*;
 import org.antlr.intellij.plugin.psi.iter.ASTIterable;
 import org.antlr.intellij.plugin.psi.iter.Tokens;
 import org.jetbrains.annotations.NotNull;
@@ -67,7 +64,7 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
             getTokenElementType(ANTLRv4Lexer.TOKEN_REF),
             getTokenElementType(ANTLRv4Lexer.RULE_REF)
     );
-    static final   TokenSet SPECS = TokenSet.create(
+    static final TokenSet SPECS = TokenSet.create(
             getRuleElementType(ANTLRv4Parser.RULE_parserRuleSpec),
             getRuleElementType(ANTLRv4Parser.RULE_lexerRule)
     );
@@ -171,7 +168,6 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
                 .peekingIterator();
 
 
-
         while (ruleSpecIterator.hasNext()) {
 
             ASTNode ruleSpec = ruleSpecIterator.next();
@@ -194,10 +190,7 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
             while (ruleSpecIterator.hasNext()) {
                 ASTNode nextSpec = ruleSpecIterator.peek();
                 ASTNode nextRule = nextSpec.findChildByType(SPECS);
-                if (nextRule == null) {
-                    System.out.println("rule was null!");
-                    break;
-                }
+                assert nextRule != null;
                 ASTNode nextRef = nextRule.findChildByType(REFS);
                 assert nextRef != null;
 
@@ -216,7 +209,7 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
 
             if (ruleRefsInGroup.size() > 1) {
                 TextRange groupRange = new TextRange(ruleSpec.getStartOffset(), endOfs);
-                FoldingDescriptor descriptor = new NamedFoldingDescriptor(rule, groupRange, null, myMakeRuleGroupPlaceholderText(ruleRefsInGroup));
+                FoldingDescriptor descriptor = new NamedFoldingDescriptor(rule, groupRange, null, makeRuleGroupPlaceholderText(ruleRefsInGroup));
                 descriptors.add(descriptor);
             } else {
                 descriptors.add(new FoldingDescriptor(rule, range));
@@ -274,8 +267,8 @@ public class ANTLRv4FoldingBuilder extends CustomFoldingBuilder {
         }
     }
 
-
-    private static String myMakeRuleGroupPlaceholderText(Iterable<ASTNode> refs) {
+// it looks like placeholder text can only be one line long so there's no point in wrapping
+    private static String makeRuleGroupPlaceholderText(Iterable<ASTNode> refs) {
         StringBuilder sb = new StringBuilder();
         for (Iterator<ASTNode> iterator = refs.iterator(); iterator.hasNext(); ) {
             sb.append(iterator.next().getChars());

--- a/src/java/org/antlr/intellij/plugin/preview/TrackpadZoomingTreeView.java
+++ b/src/java/org/antlr/intellij/plugin/preview/TrackpadZoomingTreeView.java
@@ -34,7 +34,8 @@ public class TrackpadZoomingTreeView extends TreeViewer implements Magnificator{
     static final double SCALE_MIN = 0.1;
     static final double SCALE_MAX = 2.5;
     static final double SCALE_RANGE = SCALE_MAX - SCALE_MIN;
-
+    //TODO: this is totally wrong,mathematically
+    //however, since it seems to produce the desired outcome, im going to leave it be for now.
     class ScaleModel extends DefaultBoundedRangeModel {
         ScaleModel(int ticks) {
             super(ticks / 2, 0, 1, ticks);

--- a/src/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
+++ b/src/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
@@ -1,162 +1,23 @@
 package org.antlr.intellij.plugin.psi;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.PeekingIterator;
-import com.intellij.lang.ASTNode;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.psi.impl.PsiFileFactoryImpl;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.psi.tree.TokenSet;
 import com.intellij.psi.util.PsiElementFilter;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.antlr.intellij.plugin.ANTLRv4FileRoot;
 import org.antlr.intellij.plugin.ANTLRv4Language;
 import org.antlr.intellij.plugin.ANTLRv4TokenTypes;
 import org.antlr.intellij.plugin.parser.ANTLRv4Parser;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 @SuppressWarnings("SimplifiableIfStatement")
 public class MyPsiUtils {
-
-   public static Iterable<PsiElement> directChildren(final PsiElement parent){
-        return new Iterable<PsiElement>() {
-            @NotNull
-            @Override
-            public Iterator<PsiElement> iterator() {
-              return directChildrenIterator(parent);
-            }
-        };
-    }
-
-    static Iterator<PsiElement> directChildrenIterator(final PsiElement parent) {
-        return new AbstractIterator<PsiElement>() {
-            boolean first = true;
-            PsiElement sibling;
-
-            @Override
-            protected PsiElement computeNext() {
-                PsiElement psiElement;
-                if (first) {
-                    psiElement = this.sibling = parent.getFirstChild();
-                    first = false;
-
-                } else {
-                    psiElement = this.sibling = this.sibling.getNextSibling();
-                }
-                return psiElement==null ? endOfData() : psiElement;
-
-            }
-        };
-    }
-
-
-    @Nullable
-    public static PsiElement findFirstChildOfType(final PsiElement parent, IElementType type){
-        return findFirstChildOfType(parent, TokenSet.create(type));
-    }
-    /**
-     * traverses the psi tree depth-first, returning the first it finds with the given types
-     * @param parent the element whose children will be searched
-     * @param types the types to search for
-     * @return the first child, or null;
-     */
-    @Nullable
-    public static PsiElement findFirstChildOfType(final PsiElement parent, final TokenSet types){
-        Iterator<PsiElement> iterator = findChildrenOfType(parent, types).iterator();
-        if(iterator.hasNext()) return iterator.next();
-        return null;
-    }
-
-    public static Iterable<PsiElement> findChildrenOfType(final PsiElement parent,IElementType type){
-        return findChildrenOfType(parent, TokenSet.create(type));
-    }
-	public static <T extends PsiElement> Iterable<T> findChildrenOfType(final PsiElement parent, final Class<T> cls){
-		return Iterables.filter(depthFirst(parent),cls);
-	}
-
-	public static Iterable<PsiElement> depthFirst(final PsiElement parent){
-		return new Iterable<PsiElement>() {
-			@Override
-			public Iterator<PsiElement> iterator() {
-				return new DepthFirstPsiIterator(parent);
-			}
-		};
-	}
-
-    /**
-     * Like PsiTreeUtil.findChildrenOfType, except no collection is created and it doesnt use recursion.
-     * @param parent the element whose children will be searched
-     * @param types the types to search for
-     * @return an iterable that will traverse the psi tree depth-first, including only the elements
-     * whose type is contained in the provided tokenset.
-     */
-    public static Iterable<PsiElement> findChildrenOfType(final PsiElement parent, final TokenSet types) {
-		return Iterables.filter(depthFirst(parent),includeElementTypes(types));
-    }
-
-    static Predicate<PsiElement> includeElementTypes(final TokenSet tokenSet){
-        return new Predicate<PsiElement>() {
-
-            @Override
-            public boolean apply(@Nullable PsiElement input) {
-                if(input==null) return false;
-                ASTNode node = input.getNode();
-                if(node==null)return false;
-                return tokenSet.contains(node.getElementType());
-            }
-        };
-    }
-
-    static class DepthFirstPsiIterator extends AbstractIterator<PsiElement> implements PeekingIterator<PsiElement>{
-
-        final PsiElement startFrom;
-        DepthFirstPsiIterator(PsiElement startFrom){
-            this.startFrom=this.element=startFrom;
-
-        }
-
-        PsiElement element;
-
-        private
-        boolean tryNext(PsiElement candidate) {
-            if (candidate != null) {
-                element = candidate;
-                return true;
-            }
-            else return false;
-
-        }
-
-        private
-        boolean upAndOver(PsiElement parent) {
-            while (parent != null && !parent.equals(startFrom)) {
-                if (tryNext(parent.getNextSibling())) return true;
-                else parent = parent.getParent();
-            }
-            return false;
-
-        }
-
-        @Override
-        protected
-        PsiElement computeNext() {
-            if (tryNext(element.getFirstChild()) ||
-                    tryNext(element.getNextSibling()) ||
-                    upAndOver(element.getParent())) return element;
-            return endOfData();
-
-        }
-    }
 
 	public static PsiElement findRuleSpecNodeAbove(GrammarElementRefNode element, final String ruleName) {
 		RulesNode rules = PsiTreeUtil.getContextOfType(element, RulesNode.class);

--- a/src/java/org/antlr/intellij/plugin/psi/MyTreeUtil.java
+++ b/src/java/org/antlr/intellij/plugin/psi/MyTreeUtil.java
@@ -1,8 +1,9 @@
-package org.antlr.intellij.plugin.psi.iter;
+package org.antlr.intellij.plugin.psi;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.tree.IElementType;
+import org.antlr.intellij.plugin.psi.iter.ASTFilter;
 
 /**
  * Created by jason on 2/18/15.

--- a/src/java/org/antlr/intellij/plugin/psi/iter/ASTFilter.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/ASTFilter.java
@@ -1,38 +1,10 @@
 package org.antlr.intellij.plugin.psi.iter;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.TokenType;
 
 /**
  * Created by jason on 2/17/15.
  */
-public abstract class ASTFilter {
-    public abstract boolean accept(ASTNode node);
-
-    public static ASTFilter acceptingAll() {
-        return AcceptAll.INSTANCE;
-    }
-
-    public static ASTFilter excludingWhitespace() {
-        return ExcludeWhitespace.INSTANCE;
-    }
-
-    static class ExcludeWhitespace extends ASTFilter {
-        static final ExcludeWhitespace INSTANCE = new ExcludeWhitespace();
-
-        @Override
-        public boolean accept(ASTNode node) {
-            return node.getElementType()!= TokenType.WHITE_SPACE;
-        }
-    }
-
-    static class AcceptAll extends ASTFilter {
-        static final AcceptAll INSTANCE = new AcceptAll();
-
-        @Override
-        public boolean accept(ASTNode node) {
-            return true;
-        }
-    }
-
+public interface ASTFilter {
+    boolean acceptNode(ASTNode node);
 }

--- a/src/java/org/antlr/intellij/plugin/psi/iter/ASTFilter.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/ASTFilter.java
@@ -1,0 +1,38 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.TokenType;
+
+/**
+ * Created by jason on 2/17/15.
+ */
+public abstract class ASTFilter {
+    public abstract boolean accept(ASTNode node);
+
+    public static ASTFilter acceptingAll() {
+        return AcceptAll.INSTANCE;
+    }
+
+    public static ASTFilter excludingWhitespace() {
+        return ExcludeWhitespace.INSTANCE;
+    }
+
+    static class ExcludeWhitespace extends ASTFilter {
+        static final ExcludeWhitespace INSTANCE = new ExcludeWhitespace();
+
+        @Override
+        public boolean accept(ASTNode node) {
+            return node.getElementType()!= TokenType.WHITE_SPACE;
+        }
+    }
+
+    static class AcceptAll extends ASTFilter {
+        static final AcceptAll INSTANCE = new AcceptAll();
+
+        @Override
+        public boolean accept(ASTNode node) {
+            return true;
+        }
+    }
+
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
@@ -1,10 +1,8 @@
 package org.antlr.intellij.plugin.psi.iter;
 
-import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 import org.jetbrains.annotations.NotNull;
@@ -54,77 +52,22 @@ public abstract class ASTIterable implements Iterable<ASTNode> {
     }
 
     public PsiIterable<?> mapToPsi() {
-        return PsiIterable.from(new PsiIterable<PsiElement>() {
-            @NotNull
-            @Override
-            public Iterator<PsiElement> iterator() {
-                return ast2Psi(myIterable.iterator());
-            }
-        });
-    }
-
-    static Iterator<PsiElement> ast2Psi(final Iterator<ASTNode> ast) {
-        return new Iterator<PsiElement>() {
-            @Override
-            public boolean hasNext() {
-                return ast.hasNext();
-            }
-
-            @Override
-            public PsiElement next() {
-                return ast.next().getPsi();
-            }
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        };
+        return PsiIterable.from(IteratorUtil.ast2Psi(myIterable));
     }
 
     public ASTIterable filter(IElementType type) {
-        return filter(CommonFilters.acceptingNodes(type));
+        return filter(CommonFilters.acceptingNodesWithElementType(type));
     }
 
     public ASTIterable filter(final TokenSet tokenSet) {
-        return filter(CommonFilters.acceptingNodes(tokenSet));
+        return filter(CommonFilters.acceptingNodesWithElementTypes(tokenSet));
     }
 
     public ASTIterable filter(ASTFilter filter) {
-        return from(ASTFilterIterator.createIterable(myIterable, filter));
+        return from(IteratorUtil.filter(myIterable, filter));
     }
 
-
-    static class ASTFilterIterator extends AbstractIterator<ASTNode> implements PeekingIterator<ASTNode> {
-
-        static Iterable<ASTNode> createIterable(final Iterable<ASTNode> source, final ASTFilter predicate) {
-            return new ASTIterable() {
-                @NotNull
-                @Override
-                public Iterator<ASTNode> iterator() {
-                    return new ASTFilterIterator(source.iterator(), predicate);
-                }
-            };
-        }
-
-
-        final Iterator<ASTNode> source;
-        final ASTFilter filter;
-
-        ASTFilterIterator(Iterator<ASTNode> source, ASTFilter filter) {
-            this.source = source;
-            this.filter = filter;
-        }
-
-        @Override
-        protected ASTNode computeNext() {
-            while (source.hasNext()) {
-                ASTNode next = source.next();
-                if (filter.acceptNode(next)) return next;
-            }
-            return endOfData();
-        }
+    public ASTIterable excludingWhitespace() {
+        return filter(CommonFilters.excludingWhitespace());
     }
-
-
 }

--- a/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
@@ -1,0 +1,146 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+
+/**
+ * Created by jason on 2/17/15.
+ */
+public abstract class ASTIterable implements Iterable<ASTNode> {
+
+
+    private final Iterable<ASTNode> myIterable;
+
+    protected ASTIterable() {
+        myIterable = this;
+    }
+
+    ASTIterable(@NotNull Iterable<ASTNode> iterable) {
+        myIterable = iterable;
+    }
+
+
+    public static ASTIterable from(final Iterable<ASTNode> iterable) {
+        return iterable instanceof ASTIterable ? (ASTIterable) iterable :
+                new ASTIterable(iterable) {
+                    @NotNull
+                    @Override
+                    public Iterator<ASTNode> iterator() {
+                        return iterable.iterator();
+                    }
+                };
+    }
+
+    public static ASTIterable depthFirst(ASTNode start) {
+        return from(DepthFirstTreeIterator.ASTIterator.createIterable(start));
+    }
+
+    @SuppressWarnings("LoopStatementThatDoesntLoop")
+    public ASTNode first() {
+        for (ASTNode node : this) return node;
+        return null;
+    }
+
+    public PeekingIterator<ASTNode> peekingIterator() {
+        return Iterators.peekingIterator(iterator());
+    }
+
+    public PsiIterable<?> mapToPsi() {
+        return PsiIterable.from(new PsiIterable<PsiElement>() {
+            @NotNull
+            @Override
+            public Iterator<PsiElement> iterator() {
+                return ast2Psi(myIterable.iterator());
+            }
+        });
+    }
+
+    static Iterator<PsiElement> ast2Psi(final Iterator<ASTNode> ast) {
+        return new Iterator<PsiElement>() {
+            @Override
+            public boolean hasNext() {
+                return ast.hasNext();
+            }
+
+            @Override
+            public PsiElement next() {
+                return ast.next().getPsi();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    public ASTIterable filter(IElementType type) {
+        return filter(Tokens.of(type));
+    }
+
+    public ASTIterable filter(final TokenSet tokenSet) {
+        return filter(new ASTFilter() {
+
+            @Override
+            public boolean accept(ASTNode node) {
+                return tokenSet.contains(node.getElementType());
+            }
+        });
+    }
+
+    public ASTIterable filter(final Tokens tokens) {
+        return filter(new ASTFilter() {
+            @Override
+            public boolean accept(ASTNode node) {
+                return tokens.contains(node.getElementType());
+            }
+        });
+    }
+
+
+    public ASTIterable filter(ASTFilter filter) {
+        return from(ASTFilterIterator.createIterable(myIterable, filter));
+    }
+
+
+    static class ASTFilterIterator extends AbstractIterator<ASTNode> implements PeekingIterator<ASTNode> {
+
+        static Iterable<ASTNode> createIterable(final Iterable<ASTNode> source, final ASTFilter predicate) {
+            return new ASTIterable() {
+                @NotNull
+                @Override
+                public Iterator<ASTNode> iterator() {
+                    return new ASTFilterIterator(source.iterator(), predicate);
+                }
+            };
+        }
+
+
+        final Iterator<ASTNode> source;
+        final ASTFilter filter;
+
+        ASTFilterIterator(Iterator<ASTNode> source, ASTFilter filter) {
+            this.source = source;
+            this.filter = filter;
+        }
+
+        @Override
+        protected ASTNode computeNext() {
+            while (source.hasNext()) {
+                ASTNode next = source.next();
+                if (filter.accept(next)) return next;
+            }
+            return endOfData();
+        }
+    }
+
+
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
@@ -74,4 +74,8 @@ public abstract class ASTIterable implements Iterable<ASTNode> {
     public ASTIterable excludingWhitespace() {
         return filter(CommonFilters.excludingWhitespace());
     }
+
+    public ASTIterable excludingWhitespaceAndComments() {
+        return filter(CommonFilters.excludingWhitespaceAndComments());
+    }
 }

--- a/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
@@ -41,6 +41,10 @@ public abstract class ASTIterable implements Iterable<ASTNode> {
         return from(DepthFirstTreeIterator.ASTIterator.createIterable(start));
     }
 
+    public static ASTIterable directChildrenOf(ASTNode parent) {
+        return from(IteratorUtil.directChildrenOf(parent));
+    }
+
     @SuppressWarnings("LoopStatementThatDoesntLoop")
     public ASTNode first() {
         for (ASTNode node : this) return node;

--- a/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/ASTIterable.java
@@ -83,28 +83,12 @@ public abstract class ASTIterable implements Iterable<ASTNode> {
     }
 
     public ASTIterable filter(IElementType type) {
-        return filter(Tokens.of(type));
+        return filter(CommonFilters.acceptingNodes(type));
     }
 
     public ASTIterable filter(final TokenSet tokenSet) {
-        return filter(new ASTFilter() {
-
-            @Override
-            public boolean accept(ASTNode node) {
-                return tokenSet.contains(node.getElementType());
-            }
-        });
+        return filter(CommonFilters.acceptingNodes(tokenSet));
     }
-
-    public ASTIterable filter(final Tokens tokens) {
-        return filter(new ASTFilter() {
-            @Override
-            public boolean accept(ASTNode node) {
-                return tokens.contains(node.getElementType());
-            }
-        });
-    }
-
 
     public ASTIterable filter(ASTFilter filter) {
         return from(ASTFilterIterator.createIterable(myIterable, filter));
@@ -136,7 +120,7 @@ public abstract class ASTIterable implements Iterable<ASTNode> {
         protected ASTNode computeNext() {
             while (source.hasNext()) {
                 ASTNode next = source.next();
-                if (filter.accept(next)) return next;
+                if (filter.acceptNode(next)) return next;
             }
             return endOfData();
         }

--- a/src/java/org/antlr/intellij/plugin/psi/iter/CommonFilters.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/CommonFilters.java
@@ -1,0 +1,118 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.TokenType;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+
+/**
+ * Created by jason on 2/18/15.
+ */
+public class CommonFilters {
+
+
+    public static ASTFilter acceptingAll() {
+        return AcceptAll.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends PsiElement> PsiFilter<E> acceptingAllElements() {
+        return AcceptAll.INSTANCE;
+    }
+
+    public static ASTFilter excludingWhitespace() {
+        return ExcludeWhitespace.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends PsiElement> PsiFilter<E> excludingWhitespaceElements() {
+        return ExcludeWhitespace.INSTANCE;
+    }
+
+    public static ASTFilter acceptingNodes(TokenSet tokenSet) {
+        return new TokenSetFilter(tokenSet);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends PsiElement> PsiFilter<E> acceptingElements(TokenSet tokenSet) {
+        return new TokenSetFilter(tokenSet);
+    }
+
+    public static ASTFilter acceptingNodes(IElementType type) {
+        return new ElementTypeFilter(type);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends PsiElement> PsiFilter<E> acceptingElements(IElementType type) {
+        return new ElementTypeFilter(type);
+    }
+
+    static class ElementTypeFilter implements ASTFilter, PsiFilter {
+        final IElementType elementType;
+
+        ElementTypeFilter(IElementType elementType) {
+            this.elementType = elementType;
+        }
+
+        @Override
+        public boolean acceptNode(ASTNode node) {
+            return node != null && node.getElementType() == elementType;
+        }
+
+        @Override
+        public boolean acceptElement(PsiElement element) {
+            return acceptNode(element.getNode());
+        }
+    }
+
+
+    static class TokenSetFilter implements ASTFilter, PsiFilter {
+        final TokenSet tokens;
+
+        TokenSetFilter(TokenSet tokens) {
+            this.tokens = tokens;
+        }
+
+        @Override
+        public boolean acceptNode(ASTNode node) {
+            return tokens.contains(node.getElementType());
+        }
+
+        @Override
+        public boolean acceptElement(PsiElement element) {
+            ASTNode node = element.getNode();
+            return node != null && acceptNode(node);
+        }
+    }
+
+
+    enum ExcludeWhitespace implements ASTFilter, PsiFilter {
+        INSTANCE;
+
+        @Override
+        public boolean acceptNode(ASTNode node) {
+            return node.getElementType() != TokenType.WHITE_SPACE;
+        }
+
+        @Override
+        public boolean acceptElement(PsiElement element) {
+            return element instanceof PsiWhiteSpace;
+        }
+    }
+
+    enum AcceptAll implements ASTFilter, PsiFilter {
+        INSTANCE;
+
+        @Override
+        public boolean acceptNode(ASTNode node) {
+            return true;
+        }
+
+        @Override
+        public boolean acceptElement(PsiElement element) {
+            return true;
+        }
+    }
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/CommonFilters.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/CommonFilters.java
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.TokenType;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
+import org.antlr.intellij.plugin.ANTLRv4TokenTypes;
 
 /**
  * Created by jason on 2/18/15.
@@ -24,6 +25,9 @@ public class CommonFilters {
 
     public static ASTFilter excludingWhitespace() {
         return ExcludeWhitespace.INSTANCE;
+    }
+    public static ASTFilter excludingWhitespaceAndComments(){
+        return ExcludeWhitespaceAndComments.INSTANCE;
     }
 
     @SuppressWarnings("unchecked")
@@ -99,6 +103,22 @@ public class CommonFilters {
         @Override
         public boolean acceptElement(PsiElement element) {
             return element instanceof PsiWhiteSpace;
+        }
+    }
+
+    enum ExcludeWhitespaceAndComments implements ASTFilter, PsiFilter {
+        INSTANCE;
+
+        @Override
+        public boolean acceptNode(ASTNode node) {
+            IElementType type = node.getElementType();
+            return type != TokenType.WHITE_SPACE && !ANTLRv4TokenTypes.COMMENTS.contains(type);
+        }
+
+        @Override
+        public boolean acceptElement(PsiElement element) {
+            ASTNode node = element.getNode();
+            return node != null && acceptNode(node);
         }
     }
 

--- a/src/java/org/antlr/intellij/plugin/psi/iter/CommonFilters.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/CommonFilters.java
@@ -31,7 +31,7 @@ public class CommonFilters {
         return ExcludeWhitespace.INSTANCE;
     }
 
-    public static ASTFilter acceptingNodes(TokenSet tokenSet) {
+    public static ASTFilter acceptingNodesWithElementTypes(TokenSet tokenSet) {
         return new TokenSetFilter(tokenSet);
     }
 
@@ -40,7 +40,7 @@ public class CommonFilters {
         return new TokenSetFilter(tokenSet);
     }
 
-    public static ASTFilter acceptingNodes(IElementType type) {
+    public static ASTFilter acceptingNodesWithElementType(IElementType type) {
         return new ElementTypeFilter(type);
     }
 

--- a/src/java/org/antlr/intellij/plugin/psi/iter/DepthFirstTreeIterator.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/DepthFirstTreeIterator.java
@@ -96,7 +96,6 @@ public abstract class DepthFirstTreeIterator<T> extends AbstractIterator<T> impl
     DepthFirstTreeIterator(T startFrom, TreeNavigator<T> navigator) {
         this.navigator = navigator;
         this.startFrom = this.element = startFrom;
-
     }
 
     final T startFrom;
@@ -122,7 +121,6 @@ public abstract class DepthFirstTreeIterator<T> extends AbstractIterator<T> impl
             element = candidate;
             return true;
         } else return false;
-
     }
 
 
@@ -132,7 +130,6 @@ public abstract class DepthFirstTreeIterator<T> extends AbstractIterator<T> impl
             else parent = parentOf(parent);
         }
         return false;
-
     }
 
     @Override
@@ -141,7 +138,6 @@ public abstract class DepthFirstTreeIterator<T> extends AbstractIterator<T> impl
                 tryNext(nextSiblingOf(element)) ||
                 upAndOver(parentOf(element))) return element;
         return endOfData();
-
     }
 
 }

--- a/src/java/org/antlr/intellij/plugin/psi/iter/DepthFirstTreeIterator.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/DepthFirstTreeIterator.java
@@ -1,0 +1,120 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.PeekingIterator;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+
+/**
+ * Created by jason on 2/17/15.
+ */
+public abstract class DepthFirstTreeIterator<T> extends AbstractIterator<T> implements PeekingIterator<T> {
+
+    static class ASTIterator extends DepthFirstTreeIterator<ASTNode> {
+        static Iterable<ASTNode> createIterable(final ASTNode start) {
+            return new Iterable<ASTNode>() {
+                @NotNull
+                @Override
+                public Iterator<ASTNode> iterator() {
+                    return new ASTIterator(start);
+                }
+            };
+        }
+
+        ASTIterator(ASTNode startFrom) {
+            super(startFrom);
+        }
+
+        @Override
+        protected ASTNode nextSiblingOf(ASTNode element) {
+            return element.getTreeNext();
+        }
+
+        @Override
+        protected ASTNode parentOf(ASTNode element) {
+            return element.getTreeParent();
+        }
+
+        @Override
+        protected ASTNode firstChildOf(ASTNode element) {
+            return element.getFirstChildNode();
+        }
+    }
+
+    static class PsiIterator extends DepthFirstTreeIterator<PsiElement> {
+        static Iterable<PsiElement> createIterable(final PsiElement start) {
+            return new Iterable<PsiElement>() {
+                @NotNull
+                @Override
+                public Iterator<PsiElement> iterator() {
+                    return new PsiIterator(start);
+                }
+            };
+        }
+
+        PsiIterator(PsiElement startFrom) {
+            super(startFrom);
+        }
+
+        @Override
+        protected PsiElement nextSiblingOf(PsiElement element) {
+            return element.getNextSibling();
+        }
+
+        @Override
+        protected PsiElement parentOf(PsiElement element) {
+            return element.getParent();
+        }
+
+        @Override
+        protected PsiElement firstChildOf(PsiElement element) {
+            return element.getFirstChild();
+        }
+    }
+
+    final T startFrom;
+
+    DepthFirstTreeIterator(T startFrom) {
+        this.startFrom = this.element = startFrom;
+
+    }
+
+    T element;
+
+    protected abstract T nextSiblingOf(T element);
+
+    protected abstract T parentOf(T element);
+
+    protected abstract T firstChildOf(T element);
+
+    private boolean tryNext(T candidate) {
+        if (candidate != null) {
+            element = candidate;
+            return true;
+        } else return false;
+
+    }
+
+
+    private boolean upAndOver(T parent) {
+        while (parent != null && !parent.equals(startFrom)) {
+            if (tryNext(nextSiblingOf(parent))) return true;
+            else parent = parentOf(parent);
+        }
+        return false;
+
+    }
+
+    @Override
+    protected T computeNext() {
+        if (tryNext(firstChildOf(element)) ||
+                tryNext(nextSiblingOf(element)) ||
+                upAndOver(parentOf(element))) return element;
+        return endOfData();
+
+    }
+
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/IteratorUtil.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/IteratorUtil.java
@@ -1,0 +1,74 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.PeekingIterator;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+
+/**
+ * Created by jason on 2/18/15.
+ */
+public class IteratorUtil {
+
+    static Iterable<PsiElement> ast2Psi(final Iterable<ASTNode> astIterable) {
+        return new PsiIterable<PsiElement>() {
+            @NotNull
+            @Override
+            public Iterator<PsiElement> iterator() {
+                return ast2Psi(astIterable.iterator());
+            }
+        };
+    }
+
+    static Iterator<PsiElement> ast2Psi(final Iterator<ASTNode> astIterator) {
+        return new Iterator<PsiElement>() {
+            @Override
+            public boolean hasNext() {
+                return astIterator.hasNext();
+            }
+
+            @Override
+            public PsiElement next() {
+                return astIterator.next().getPsi();
+            }
+
+            @Override
+            public void remove() {
+                astIterator.remove();
+            }
+        };
+    }
+
+    static Iterable<ASTNode> filter(final Iterable<ASTNode> source, final ASTFilter predicate) {
+        return new ASTIterable() {
+            @NotNull
+            @Override
+            public Iterator<ASTNode> iterator() {
+                return new ASTFilterIterator(source.iterator(), predicate);
+            }
+        };
+    }
+
+    static class ASTFilterIterator extends AbstractIterator<ASTNode> implements PeekingIterator<ASTNode> {
+
+        final Iterator<ASTNode> source;
+        final ASTFilter filter;
+
+        ASTFilterIterator(Iterator<ASTNode> source, ASTFilter filter) {
+            this.source = source;
+            this.filter = filter;
+        }
+
+        @Override
+        protected ASTNode computeNext() {
+            while (source.hasNext()) {
+                ASTNode next = source.next();
+                if (filter.acceptNode(next)) return next;
+            }
+            return endOfData();
+        }
+    }
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/IteratorUtil.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/IteratorUtil.java
@@ -74,6 +74,7 @@ public class IteratorUtil {
         }
 
         ASTNode node;
+        boolean first = true;
 
         @Override
         public boolean hasNext() {
@@ -87,6 +88,10 @@ public class IteratorUtil {
 
         @Override
         public ASTNode next() {
+            if (first) {
+                first = false;
+                return node;
+            }
             return node = node.getTreeNext();
         }
 

--- a/src/java/org/antlr/intellij/plugin/psi/iter/IteratorUtil.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/IteratorUtil.java
@@ -7,11 +7,124 @@ import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
 
 /**
  * Created by jason on 2/18/15.
  */
 public class IteratorUtil {
+    @SuppressWarnings("unchecked")
+    static <T> Iterable<T> emptyIterable() {
+        return EmptyIter.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> Iterator<T> emptyIterator() {
+        return EmptyIter.INSTANCE;
+    }
+
+    enum EmptyIter implements Iterable, Iterator, PeekingIterator {
+        INSTANCE;
+
+        @Override
+        public Object peek() {
+            throw new NoSuchElementException();
+        }
+
+        @NotNull
+        @Override
+        public Iterator iterator() {
+            return this;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public Object next() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    static Iterable<ASTNode> directChildrenOf(final ASTNode parent) {
+        if (parent == null) return emptyIterable();
+        return new ASTIterable() {
+            @NotNull
+            @Override
+            public Iterator<ASTNode> iterator() {
+                ASTNode firstChild = parent.getFirstChildNode();
+                if (firstChild == null) return emptyIterator();
+                return new DirectChildrenIterator(firstChild);
+            }
+        };
+    }
+
+    static class DirectChildrenIterator implements ListIterator<ASTNode>, PeekingIterator<ASTNode> {
+        public DirectChildrenIterator(ASTNode node) {
+            this.node = node;
+        }
+
+        ASTNode node;
+
+        @Override
+        public boolean hasNext() {
+            return node.getTreeNext() != null;
+        }
+
+        @Override
+        public ASTNode peek() {
+            return node.getTreeNext();
+        }
+
+        @Override
+        public ASTNode next() {
+            return node = node.getTreeNext();
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return node.getTreePrev() != null;
+        }
+
+        @Override
+        public ASTNode previous() {
+            return node = node.getTreePrev();
+        }
+
+        @Override
+        public int nextIndex() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int previousIndex() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(ASTNode node) {
+
+        }
+
+        @Override
+        public void add(ASTNode node) {
+
+        }
+    }
 
     static Iterable<PsiElement> ast2Psi(final Iterable<ASTNode> astIterable) {
         return new PsiIterable<PsiElement>() {

--- a/src/java/org/antlr/intellij/plugin/psi/iter/MyTreeUtil.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/MyTreeUtil.java
@@ -1,12 +1,21 @@
 package org.antlr.intellij.plugin.psi.iter;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.tree.IElementType;
 
 /**
  * Created by jason on 2/18/15.
  */
 public class MyTreeUtil {
+
+    public static ASTNode nextNonWhitespaceNode(ASTNode node) {
+        for (ASTNode next = node.getTreeNext(); next != null; next = next.getTreeNext()) {
+            if (!(next instanceof PsiWhiteSpace)) return next;
+        }
+        return null;
+    }
+
     public static ASTNode findChild(ASTNode parent, ASTFilter filter) {
         return findSibling(parent.getFirstChildNode(), filter);
     }

--- a/src/java/org/antlr/intellij/plugin/psi/iter/MyTreeUtil.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/MyTreeUtil.java
@@ -1,6 +1,7 @@
 package org.antlr.intellij.plugin.psi.iter;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.tree.IElementType;
 
 /**
  * Created by jason on 2/18/15.
@@ -8,6 +9,19 @@ import com.intellij.lang.ASTNode;
 public class MyTreeUtil {
     public static ASTNode findChild(ASTNode parent, ASTFilter filter) {
         return findSibling(parent.getFirstChildNode(), filter);
+    }
+
+    public static ASTNode findChild(ASTNode parent, IElementType type) {
+        return findSibling(parent.getFirstChildNode(), type);
+    }
+
+    public static ASTNode findSibling(ASTNode start, IElementType type) {
+        ASTNode child = start;
+        while (true) {
+            if (child == null) return null;
+            if (child.getElementType() == type) return child;
+            child = child.getTreeNext();
+        }
     }
 
     public static ASTNode findSibling(ASTNode start, ASTFilter filter) {

--- a/src/java/org/antlr/intellij/plugin/psi/iter/MyTreeUtil.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/MyTreeUtil.java
@@ -1,0 +1,21 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.intellij.lang.ASTNode;
+
+/**
+ * Created by jason on 2/18/15.
+ */
+public class MyTreeUtil {
+    public static ASTNode findChild(ASTNode parent, ASTFilter filter) {
+        return findSibling(parent.getFirstChildNode(), filter);
+    }
+
+    public static ASTNode findSibling(ASTNode start, ASTFilter filter) {
+        ASTNode child = start;
+        while (true) {
+            if (child == null) return null;
+            if (filter.acceptNode(child)) return child;
+            child = child.getTreeNext();
+        }
+    }
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/PsiFilter.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/PsiFilter.java
@@ -1,0 +1,22 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.intellij.psi.PsiElement;
+
+/**
+ * Created by jason on 2/17/15.
+ */
+public abstract class PsiFilter<E extends PsiElement> {
+    @SuppressWarnings("unchecked")
+    public static <T extends PsiElement> PsiFilter<T> acceptingAll() {
+        return ACCEPT_ALL;
+    }
+
+    static final PsiFilter ACCEPT_ALL = new PsiFilter() {
+        @Override
+        public boolean accept(PsiElement node) {
+            return true;
+        }
+    };
+
+    public abstract boolean accept(E node);
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/PsiFilter.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/PsiFilter.java
@@ -5,18 +5,6 @@ import com.intellij.psi.PsiElement;
 /**
  * Created by jason on 2/17/15.
  */
-public abstract class PsiFilter<E extends PsiElement> {
-    @SuppressWarnings("unchecked")
-    public static <T extends PsiElement> PsiFilter<T> acceptingAll() {
-        return ACCEPT_ALL;
-    }
-
-    static final PsiFilter ACCEPT_ALL = new PsiFilter() {
-        @Override
-        public boolean accept(PsiElement node) {
-            return true;
-        }
-    };
-
-    public abstract boolean accept(E node);
+public interface PsiFilter<E extends PsiElement> {
+    boolean acceptElement(E element);
 }

--- a/src/java/org/antlr/intellij/plugin/psi/iter/PsiIterable.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/PsiIterable.java
@@ -93,7 +93,7 @@ public abstract class PsiIterable<E extends PsiElement> implements Iterable<E> {
         protected T computeNext() {
             while (source.hasNext()) {
                 T next = source.next();
-                if (filter.accept(next())) return next;
+                if (filter.acceptElement(next())) return next;
             }
             return endOfData();
         }
@@ -128,7 +128,7 @@ public abstract class PsiIterable<E extends PsiElement> implements Iterable<E> {
         final PsiFilter<T> filter;
 
         public PsiClassFilterIterator(Iterator<? super PsiElement> source, Class<T> type) {
-            this(source, type, PsiFilter.<T>acceptingAll());
+            this(source, type, CommonFilters.<T>acceptingAllElements());
         }
 
         protected PsiClassFilterIterator(Iterator<? super PsiElement> source, Class<T> type, PsiFilter<T> filter) {

--- a/src/java/org/antlr/intellij/plugin/psi/iter/PsiIterable.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/PsiIterable.java
@@ -1,0 +1,151 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+
+/**
+ * Created by jason on 2/17/15.
+ */
+public abstract class PsiIterable<E extends PsiElement> implements Iterable<E> {
+
+
+    private final Iterable<E> myIterable;
+
+    protected PsiIterable() {
+        myIterable = this;
+    }
+
+    PsiIterable(@NotNull Iterable<E> iterable) {
+        myIterable = iterable;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public static <T extends PsiElement> PsiIterable<T> from(final Iterable<T> iterable) {
+        if (iterable instanceof PsiIterable) return (PsiIterable) iterable;
+        else return new PsiIterable<T>(iterable) {
+            @NotNull
+            @Override
+            public Iterator<T> iterator() {
+                return iterable.iterator();
+            }
+        };
+    }
+
+    public static PsiIterable<?> depthFirst(final PsiElement start) {
+        return from(DepthFirstTreeIterator.PsiIterator.createIterable(start));
+    }
+
+    @SuppressWarnings("unchecked")
+    Iterable<PsiElement> it() {
+        return (Iterable<PsiElement>) myIterable;
+    }
+
+    public <T extends PsiElement> PsiIterable<T> filter(Class<T> cls) {
+        return from(PsiClassFilterIterator.iterable(it(), cls));
+    }
+
+    public <T extends PsiElement> PsiIterable<T> filter(Class<T> cls, PsiFilter<T> filter) {
+        return from(PsiClassFilterIterator.iterable(it(), cls, filter));
+    }
+
+
+    public PsiIterable<E> filter(PsiFilter<E> filter) {
+        return from(PsiFilterIterator.iterable(myIterable, filter));
+    }
+
+    @SuppressWarnings("LoopStatementThatDoesntLoop")
+    public E first() {
+        for (E node : this) return node;
+        return null;
+    }
+
+
+    public PeekingIterator<E> peekingIterator() {
+        return Iterators.peekingIterator(iterator());
+    }
+
+    static class PsiFilterIterator<T extends PsiElement> extends AbstractIterator<T> {
+        static <E extends PsiElement> Iterable<E> iterable(final Iterable<E> source, final PsiFilter<E> filter) {
+            return new PsiIterable<E>() {
+                @NotNull
+                @Override
+                public Iterator<E> iterator() {
+                    return new PsiFilterIterator<E>(source.iterator(), filter);
+                }
+            };
+        }
+
+        final Iterator<T> source;
+        final PsiFilter<T> filter;
+
+        PsiFilterIterator(Iterator<T> source, PsiFilter<T> filter) {
+            this.source = source;
+            this.filter = filter;
+        }
+
+        @Override
+        protected T computeNext() {
+            while (source.hasNext()) {
+                T next = source.next();
+                if (filter.accept(next())) return next;
+            }
+            return endOfData();
+        }
+    }
+
+
+    static class PsiClassFilterIterator<T extends PsiElement> extends AbstractIterator<T> {
+        static <EE extends PsiElement> Iterable<EE> iterable(final Iterable<PsiElement> source, final Class<EE> cls, final PsiFilter<EE> predicate) {
+            return new PsiIterable<EE>() {
+                @NotNull
+                @Override
+                public Iterator<EE> iterator() {
+                    return new PsiClassFilterIterator<EE>(source.iterator(), cls, predicate);
+                }
+            };
+        }
+
+
+        static <EE extends PsiElement> Iterable<EE> iterable(final Iterable<PsiElement> source, final Class<EE> cls) {
+            return new PsiIterable<EE>() {
+                @NotNull
+                @Override
+                public Iterator<EE> iterator() {
+                    return new PsiClassFilterIterator<EE>(source.iterator(), cls);
+                }
+            };
+        }
+
+
+        final Iterator<? super PsiElement> source;
+        final Class<T> type;
+        final PsiFilter<T> filter;
+
+        public PsiClassFilterIterator(Iterator<? super PsiElement> source, Class<T> type) {
+            this(source, type, PsiFilter.<T>acceptingAll());
+        }
+
+        protected PsiClassFilterIterator(Iterator<? super PsiElement> source, Class<T> type, PsiFilter<T> filter) {
+            this.source = source;
+            this.type = type;
+            this.filter = filter;
+        }
+
+        @Override
+        protected T computeNext() {
+            while (source.hasNext()) {
+                Object next = source.next();
+                if (type.isInstance(next)) {
+                    return type.cast(next);
+                }
+            }
+            return endOfData();
+        }
+    }
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/Tokens.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/Tokens.java
@@ -1,0 +1,101 @@
+package org.antlr.intellij.plugin.psi.iter;
+
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.TreeSet;
+
+/**
+ * Created by jason on 2/17/15.
+ */
+public abstract class Tokens {
+    public abstract boolean contains(IElementType type);
+
+    static final Comparator<IElementType> ELEMENT_TYPE_COMPARATOR = new Comparator<IElementType>() {
+        @Override
+        public int compare(@NotNull IElementType a, @NotNull IElementType b) {
+            return a.getIndex() - b.getIndex();
+        }
+    };
+
+
+    public static Tokens of(IElementType... types) {
+        TreeSet<IElementType> typeSet = new TreeSet<IElementType>(ELEMENT_TYPE_COMPARATOR);
+        Collections.addAll(typeSet, types);
+        IElementType[] arr = typeSet.isEmpty() ? IElementType.EMPTY_ARRAY : typeSet.toArray(new IElementType[typeSet.size()]);
+        switch (typeSet.size()) {
+            case 0:
+                return NONE;
+            case 1:
+                return one(arr[0]);
+            case 2:
+                return two(arr[0], arr[1]);
+            case 3:
+                return three(arr[0], arr[1], arr[2]);
+            case 4:
+                return four(arr[0], arr[1], arr[2], arr[3]);
+            default:
+                return fromTokenSet(arr);
+
+        }
+    }
+
+    static final Tokens NONE = new Tokens() {
+        @Override
+        public boolean contains(IElementType type) {
+            return false;
+        }
+    };
+
+
+    static Tokens one(final IElementType t) {
+        return new Tokens() {
+            @Override
+            public boolean contains(IElementType type) {
+                return type == t;
+            }
+        };
+    }
+
+    static Tokens two(final IElementType t0, final IElementType t1) {
+        return new Tokens() {
+            @Override
+            public boolean contains(IElementType type) {
+                return type == t0 || type == t1;
+            }
+        };
+    }
+
+    static Tokens three(final IElementType t0, final IElementType t1, final IElementType t2) {
+        return new Tokens() {
+            @Override
+            public boolean contains(IElementType type) {
+                return type == t0 || type == t1 || type == t2;
+            }
+        };
+    }
+
+    static Tokens four(final IElementType t0, final IElementType t1, final IElementType t2, final IElementType t3) {
+        return new Tokens() {
+            @Override
+            public boolean contains(IElementType type) {
+                return type == t0 || type == t1 || type == t2 || type == t3;
+            }
+        };
+    }
+
+    static Tokens fromTokenSet(final IElementType[] types) {
+        return new Tokens() {
+            final TokenSet tokenSet = TokenSet.create(types);
+
+            @Override
+            public boolean contains(IElementType type) {
+                return tokenSet.contains(type);
+            }
+        };
+    }
+
+}

--- a/src/java/org/antlr/intellij/plugin/psi/iter/Tokens.java
+++ b/src/java/org/antlr/intellij/plugin/psi/iter/Tokens.java
@@ -1,5 +1,7 @@
 package org.antlr.intellij.plugin.psi.iter;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 import org.jetbrains.annotations.NotNull;
@@ -11,8 +13,19 @@ import java.util.TreeSet;
 /**
  * Created by jason on 2/17/15.
  */
-public abstract class Tokens {
+public abstract class Tokens implements ASTFilter, PsiFilter {
     public abstract boolean contains(IElementType type);
+
+    @Override
+    public boolean acceptNode(ASTNode node) {
+        return contains(node.getElementType());
+    }
+
+    @Override
+    public boolean acceptElement(PsiElement element) {
+        ASTNode node = element.getNode();
+        return node != null && contains(node.getElementType());
+    }
 
     static final Comparator<IElementType> ELEMENT_TYPE_COMPARATOR = new Comparator<IElementType>() {
         @Override

--- a/test/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilderTest.java
+++ b/test/java/org/antlr/intellij/plugin/folding/ANTLRv4FoldingBuilderTest.java
@@ -1,0 +1,33 @@
+package org.antlr.intellij.plugin.folding;
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+
+import java.io.File;
+
+public class ANTLRv4FoldingBuilderTest extends LightPlatformCodeInsightFixtureTestCase {
+
+   // @Test
+    public void testANTLRv4Lexer() throws Exception {
+        doTest();
+    }
+
+    public void testANTLRv4Parser() throws Exception {
+        doTest();
+    }
+
+    private void doTest(){
+        myFixture.testFoldingWithCollapseStatus(getTestDataPath() + "/" + getTestName(false) + ".folding.g4");
+    }
+
+    @Override
+    protected boolean isCommunity() {
+        return true;
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        File f = new File("test/testData/grammars/folding/").getAbsoluteFile();
+        assertTrue(f.exists());
+        return f.getAbsolutePath();
+    }
+}

--- a/test/testData/grammars/ANTLRv4Lexer.g4
+++ b/test/testData/grammars/ANTLRv4Lexer.g4
@@ -1,0 +1,334 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2014 Terence Parr
+ *  Copyright (c) 2014 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** A grammar for ANTLR v4 tokens */
+lexer grammar ANTLRv4Lexer;
+
+tokens {
+	TOKEN_REF,
+	RULE_REF,
+	LEXER_CHAR_SET
+}
+
+@members {
+	/** Track whether we are inside of a rule and whether it is lexical parser.
+	 *  _currentRuleType==Token.INVALID_TYPE means that we are outside of a rule.
+	 *  At the first sign of a rule name reference and _currentRuleType==invalid,
+	 *  we can assume that we are starting a parser rule. Similarly, seeing
+	 *  a token reference when not already in rule means starting a token
+	 *  rule. The terminating ';' of a rule, flips this back to invalid type.
+	 *
+	 *  This is not perfect logic but works. For example, "grammar T;" means
+	 *  that we start and stop a lexical rule for the "T;". Dangerous but works.
+	 *
+	 *  The whole point of this state information is to distinguish
+	 *  between [..arg actions..] and [charsets]. Char sets can only occur in
+	 *  lexical rules and arg actions cannot occur.
+	 */
+	private int _currentRuleType = Token.INVALID_TYPE;
+
+	public int getCurrentRuleType() {
+		return _currentRuleType;
+	}
+
+	public void setCurrentRuleType(int ruleType) {
+		this._currentRuleType = ruleType;
+	}
+
+	protected void handleBeginArgAction() {
+		if (inLexerRule()) {
+			pushMode(LexerCharSet);
+			more();
+		}
+		else {
+			pushMode(ArgAction);
+			more();
+		}
+	}
+
+	@Override
+	public Token emit() {
+		if (_type == ID) {
+			String firstChar = _input.getText(Interval.of(_tokenStartCharIndex, _tokenStartCharIndex));
+			if (Character.isUpperCase(firstChar.charAt(0))) {
+				_type = TOKEN_REF;
+			} else {
+				_type = RULE_REF;
+			}
+
+			if (_currentRuleType == Token.INVALID_TYPE) { // if outside of rule def
+				_currentRuleType = _type;                 // set to inside lexer or parser rule
+			}
+		}
+		else if (_type == SEMI) {                  // exit rule def
+			_currentRuleType = Token.INVALID_TYPE;
+		}
+
+		return super.emit();
+	}
+
+	private boolean inLexerRule() {
+		return _currentRuleType == TOKEN_REF;
+	}
+	private boolean inParserRule() { // not used, but added for clarity
+		return _currentRuleType == RULE_REF;
+	}
+}
+
+DOC_COMMENT
+	:	'/**' .*? ('*/' | EOF)
+	;
+
+BLOCK_COMMENT
+	:	'/*' .*? ('*/' | EOF)  -> channel(HIDDEN)
+	;
+
+LINE_COMMENT
+	:	'//' ~[\r\n]*  -> channel(HIDDEN)
+	;
+
+BEGIN_ARG_ACTION
+	:	'[' {handleBeginArgAction();}
+	;
+
+// OPTIONS and TOKENS must also consume the opening brace that captures
+// their option block, as this is teh easiest way to parse it separate
+// to an ACTION block, despite it usingthe same {} delimiters.
+//
+OPTIONS      : 'options' [ \t\f\n\r]* '{'  ;
+TOKENS		 : 'tokens'  [ \t\f\n\r]* '{'  ;
+
+IMPORT       : 'import'               ;
+FRAGMENT     : 'fragment'             ;
+LEXER        : 'lexer'                ;
+PARSER       : 'parser'               ;
+GRAMMAR      : 'grammar'              ;
+PROTECTED    : 'protected'            ;
+PUBLIC       : 'public'               ;
+PRIVATE      : 'private'              ;
+RETURNS      : 'returns'              ;
+LOCALS       : 'locals'               ;
+THROWS       : 'throws'               ;
+CATCH        : 'catch'                ;
+FINALLY      : 'finally'              ;
+MODE         : 'mode'                 ;
+
+COLON        : ':'                    ;
+COLONCOLON   : '::'                   ;
+COMMA        : ','                    ;
+SEMI         : ';'                    ;
+LPAREN       : '('                    ;
+RPAREN       : ')'                    ;
+RARROW       : '->'                   ;
+LT           : '<'                    ;
+GT           : '>'                    ;
+ASSIGN       : '='                    ;
+QUESTION     : '?'                    ;
+STAR         : '*'                    ;
+PLUS         : '+'                    ;
+PLUS_ASSIGN  : '+='                   ;
+OR           : '|'                    ;
+DOLLAR       : '$'                    ;
+DOT		     : '.'                    ;
+RANGE        : '..'                   ;
+AT           : '@'                    ;
+POUND        : '#'                    ;
+NOT          : '~'                    ;
+RBRACE       : '}'                    ;
+
+/** Allow unicode rule/token names */
+ID	:	NameStartChar NameChar*;
+
+fragment
+NameChar
+	:   NameStartChar
+	|   '0'..'9'
+	|   '_'
+	|   '\u00B7'
+	|   '\u0300'..'\u036F'
+	|   '\u203F'..'\u2040'
+	;
+
+fragment
+NameStartChar
+	:   'A'..'Z'
+	|   'a'..'z'
+	|   '\u00C0'..'\u00D6'
+	|   '\u00D8'..'\u00F6'
+	|   '\u00F8'..'\u02FF'
+	|   '\u0370'..'\u037D'
+	|   '\u037F'..'\u1FFF'
+	|   '\u200C'..'\u200D'
+	|   '\u2070'..'\u218F'
+	|   '\u2C00'..'\u2FEF'
+	|   '\u3001'..'\uD7FF'
+	|   '\uF900'..'\uFDCF'
+	|   '\uFDF0'..'\uFFFD'
+	; // ignores | ['\u10000-'\uEFFFF] ;
+
+INT	: [0-9]+
+	;
+
+// ANTLR makes no distinction between a single character literal and a
+// multi-character string. All literals are single quote delimited and
+// may contain unicode escape sequences of the form \uxxxx, where x
+// is a valid hexadecimal number (as per Java basically).
+STRING_LITERAL
+	:  '\'' (ESC_SEQ | ~['\r\n\\])* '\''
+	;
+
+UNTERMINATED_STRING_LITERAL
+	:  '\'' (ESC_SEQ | ~['\r\n\\])*
+	;
+
+// Any kind of escaped character that we can embed within ANTLR
+// literal strings.
+fragment
+ESC_SEQ
+	:	'\\'
+		(	// The standard escaped character set such as tab, newline, etc.
+			[btnfr"'\\]
+		|	// A Java style Unicode escape sequence
+			UNICODE_ESC
+		|	// Invalid escape
+			.
+		|	// Invalid escape at end of file
+			EOF
+		)
+	;
+
+fragment
+UNICODE_ESC
+    :   'u' (HEX_DIGIT (HEX_DIGIT (HEX_DIGIT HEX_DIGIT?)?)?)?
+    ;
+
+fragment
+HEX_DIGIT : [0-9a-fA-F]	;
+
+WS  :	[ \t\r\n\f]+ -> channel(HIDDEN)	;
+
+// Many language targets use {} as block delimiters and so we
+// must recursively match {} delimited blocks to balance the
+// braces. Additionally, we must make some assumptions about
+// literal string representation in the target language. We assume
+// that they are delimited by ' or " and so consume these
+// in their own alts so as not to inadvertantly match {}.
+
+ACTION
+	:	'{'
+		(	ACTION
+		|	ACTION_ESCAPE
+        |	ACTION_STRING_LITERAL
+        |	ACTION_CHAR_LITERAL
+        |	'/*' .*? '*/' // ('*/' | EOF)
+        |	'//' ~[\r\n]*
+        |	.
+		)*?
+		('}'|EOF)
+	;
+
+fragment
+ACTION_ESCAPE
+		:   '\\' .
+		;
+
+fragment
+ACTION_STRING_LITERAL
+        :	'"' (ACTION_ESCAPE | ~["\\])* '"'
+        ;
+
+fragment
+ACTION_CHAR_LITERAL
+        :	'\'' (ACTION_ESCAPE | ~['\\])* '\''
+        ;
+
+// -----------------
+// Illegal Character
+//
+// This is an illegal character trap which is always the last rule in the
+// lexer specification. It matches a single character of any value and being
+// the last rule in the file will match when no other rule knows what to do
+// about the character. It is reported as an error but is not passed on to the
+// parser. This means that the parser to deal with the gramamr file anyway
+// but we will not try to analyse or code generate from a file with lexical
+// errors.
+//
+ERRCHAR
+	:	.	-> channel(HIDDEN)
+	;
+
+mode ArgAction; // E.g., [int x, List<String> a[]]
+
+	NESTED_ARG_ACTION
+		:	'['                         -> more, pushMode(ArgAction)
+		;
+
+	ARG_ACTION_ESCAPE
+		:   '\\' .                      -> more
+		;
+
+    ARG_ACTION_STRING_LITERAL
+        :	('"' ('\\' . | ~["\\])* '"')-> more
+        ;
+
+    ARG_ACTION_CHAR_LITERAL
+        :	('"' '\\' . | ~["\\] '"')   -> more
+        ;
+
+    ARG_ACTION
+		:   ']'                         -> popMode
+		;
+
+	UNTERMINATED_ARG_ACTION // added this to return non-EOF token type here. EOF did something weird
+		:	EOF							-> popMode
+		;
+
+    ARG_ACTION_CHAR // must be last
+        :   .                           -> more
+        ;
+
+
+mode LexerCharSet;
+
+	LEXER_CHAR_SET_BODY
+		:	(	~[\]\\]
+			|	'\\' .
+			)
+                                        -> more
+		;
+
+	LEXER_CHAR_SET
+		:   ']'                         -> popMode
+		;
+
+	UNTERMINATED_CHAR_SET
+		:	EOF							-> popMode
+		;
+

--- a/test/testData/grammars/ANTLRv4Parser.g4
+++ b/test/testData/grammars/ANTLRv4Parser.g4
@@ -1,0 +1,366 @@
+/*
+ * [The "BSD license"]
+ *  Copyright (c) 2013 Terence Parr
+ *  Copyright (c) 2013 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** A grammar for ANTLR v4 written in ANTLR v4.
+*/
+parser grammar ANTLRv4Parser;
+
+options {
+	tokenVocab=ANTLRv4Lexer;
+}
+
+// The main entry point for parsing a v4 grammar.
+grammarSpec
+	:	DOC_COMMENT?
+		grammarType id SEMI
+		prequelConstruct*
+		rules
+		modeSpec*
+		EOF
+	;
+
+grammarType
+	:	(	LEXER GRAMMAR
+		|	PARSER GRAMMAR
+		|	GRAMMAR
+		)
+	;
+
+// This is the list of all constructs that can be declared before
+// the set of rules that compose the grammar, and is invoked 0..n
+// times by the grammarPrequel rule.
+prequelConstruct
+	:	optionsSpec
+	|	delegateGrammars
+	|	tokensSpec
+	|	action
+	;
+
+// A list of options that affect analysis and/or code generation
+optionsSpec
+	:	OPTIONS (option SEMI)* RBRACE
+	;
+
+option
+	:	id ASSIGN optionValue
+	;
+
+optionValue
+	:	id (DOT id)*
+	|	STRING_LITERAL
+	|	ACTION
+	|	INT
+	;
+
+delegateGrammars
+	:	IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
+	;
+
+delegateGrammar
+	:	id ASSIGN id
+	|	id
+	;
+
+tokensSpec
+	:	TOKENS id (COMMA id)* COMMA? RBRACE
+	;
+
+/** Match stuff like @parser::members {int i;} */
+action
+	:	AT (actionScopeName COLONCOLON)? id ACTION
+	;
+
+/** Sometimes the scope names will collide with keywords; allow them as
+ *  ids for action scopes.
+ */
+actionScopeName
+	:	id
+	|	LEXER
+	|	PARSER
+	;
+
+modeSpec
+	:	MODE id SEMI lexerRule*
+	;
+
+rules
+	:	ruleSpec*
+	;
+
+ruleSpec
+	:	parserRuleSpec
+	|	lexerRule
+	;
+
+parserRuleSpec
+	:	DOC_COMMENT?
+        ruleModifiers? RULE_REF ARG_ACTION?
+        ruleReturns? throwsSpec? localsSpec?
+		rulePrequel*
+		COLON
+            ruleBlock
+		SEMI
+		exceptionGroup
+	;
+
+exceptionGroup
+	:	exceptionHandler* finallyClause?
+	;
+
+exceptionHandler
+	:	CATCH ARG_ACTION ACTION
+	;
+
+finallyClause
+	:	FINALLY ACTION
+	;
+
+rulePrequel
+	:	optionsSpec
+	|	ruleAction
+	;
+
+ruleReturns
+	:	RETURNS ARG_ACTION
+	;
+
+throwsSpec
+	:	THROWS id (COMMA id)*
+	;
+
+localsSpec
+	:	LOCALS ARG_ACTION
+	;
+
+/** Match stuff like @init {int i;} */
+ruleAction
+	:	AT id ACTION
+	;
+
+ruleModifiers
+	:	ruleModifier+
+	;
+
+// An individual access modifier for a rule. The 'fragment' modifier
+// is an internal indication for lexer rules that they do not match
+// from the input but are like subroutines for other lexer rules to
+// reuse for certain lexical patterns. The other modifiers are passed
+// to the code generation templates and may be ignored by the template
+// if they are of no use in that language.
+ruleModifier
+	:	PUBLIC
+	|	PRIVATE
+	|	PROTECTED
+	|	FRAGMENT
+	;
+
+ruleBlock
+	:	ruleAltList
+	;
+
+ruleAltList
+	:	labeledAlt (OR labeledAlt)*
+	;
+
+labeledAlt
+	:	alternative (POUND id)?
+	;
+
+lexerRule
+	:	DOC_COMMENT? FRAGMENT?
+		TOKEN_REF COLON lexerRuleBlock SEMI
+	;
+
+lexerRuleBlock
+	:	lexerAltList
+	;
+
+lexerAltList
+	:	lexerAlt (OR lexerAlt)*
+	;
+
+lexerAlt
+	:	lexerElements lexerCommands?
+	|
+	;
+
+lexerElements
+	:	lexerElement+
+	;
+
+lexerElement
+	:	labeledLexerElement ebnfSuffix?
+	|	lexerAtom ebnfSuffix?
+	|	lexerBlock ebnfSuffix?
+	|	ACTION QUESTION? // actions only allowed at end of outer alt actually,
+                         // but preds can be anywhere
+	;
+
+labeledLexerElement
+	:	id (ASSIGN|PLUS_ASSIGN)
+		(	lexerAtom
+		|	block
+		)
+	;
+
+lexerBlock
+	:	LPAREN lexerAltList RPAREN
+	;
+
+// E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop
+lexerCommands
+	:	RARROW lexerCommand (COMMA lexerCommand)*
+	;
+
+lexerCommand
+	:	lexerCommandName LPAREN lexerCommandExpr RPAREN
+	|	lexerCommandName
+	;
+
+lexerCommandName
+	:	id
+	|	MODE
+	;
+
+lexerCommandExpr
+	:	id
+	|	INT
+	;
+
+altList
+	:	alternative (OR alternative)*
+	;
+
+alternative
+	:	elementOptions? element*
+	;
+
+element
+	:	labeledElement
+		(	ebnfSuffix
+		|
+		)
+	|	atom
+		(	ebnfSuffix
+		|
+		)
+	|	ebnf
+	|	ACTION QUESTION? // SEMPRED is ACTION followed by QUESTION
+	;
+
+labeledElement
+	:	id (ASSIGN|PLUS_ASSIGN)
+		(	atom
+		|	block
+		)
+	;
+
+ebnf:	block blockSuffix?
+	;
+
+blockSuffix
+	:	ebnfSuffix // Standard EBNF
+	;
+
+ebnfSuffix
+	:	QUESTION QUESTION?
+  	|	STAR QUESTION?
+   	|	PLUS QUESTION?
+	;
+
+lexerAtom
+	:	range
+	|	terminal
+	|	RULE_REF
+	|	notSet
+	|	LEXER_CHAR_SET
+	|	DOT elementOptions?
+	;
+
+atom
+	:	range // Range x..y - only valid in lexers
+	|	terminal
+	|	ruleref
+	|	notSet
+	|	DOT elementOptions?
+	;
+
+notSet
+	:	NOT setElement
+	|	NOT blockSet
+	;
+
+blockSet
+	:	LPAREN setElement (OR setElement)* RPAREN
+	;
+
+setElement
+	:	TOKEN_REF elementOptions?
+	|	STRING_LITERAL elementOptions?
+	|	range
+	|	LEXER_CHAR_SET
+	;
+
+block
+	:	LPAREN
+		( optionsSpec? ruleAction* COLON )?
+		altList
+		RPAREN
+	;
+
+ruleref
+	:	RULE_REF ARG_ACTION? elementOptions?
+	;
+
+range
+	: STRING_LITERAL RANGE STRING_LITERAL
+	;
+
+terminal
+	:   TOKEN_REF elementOptions?
+	|   STRING_LITERAL elementOptions?
+	;
+
+// Terminals may be adorned with certain options when
+// reference in the grammar: TOK<,,,>
+elementOptions
+	:	LT elementOption (COMMA elementOption)* GT
+	;
+
+elementOption
+	:	// This format indicates the default node option
+		id
+	|	// This format indicates option assignment
+		id ASSIGN (id | STRING_LITERAL)
+	;
+
+id	:	RULE_REF
+	|	TOKEN_REF
+	;

--- a/test/testData/grammars/folding/ANTLRv4Lexer.folding.g4
+++ b/test/testData/grammars/folding/ANTLRv4Lexer.folding.g4
@@ -102,19 +102,19 @@ tokens <fold text='...' expand='false'>{
 	}
 }</fold>
 
-DOC_COMMENT<fold text=':...' expand='true'>
+DOC_COMMENT<fold text=':...;' expand='true'>
 	:	'/**' .*? ('*/' | EOF)
 	;</fold>
 
-BLOCK_COMMENT<fold text=':...' expand='true'>
+BLOCK_COMMENT<fold text=':...;' expand='true'>
 	:	'/*' .*? ('*/' | EOF)  -> channel(HIDDEN)
 	;</fold>
 
-LINE_COMMENT<fold text=':...' expand='true'>
+LINE_COMMENT<fold text=':...;' expand='true'>
 	:	'//' ~[\r\n]*  -> channel(HIDDEN)
 	;</fold>
 
-BEGIN_ARG_ACTION<fold text=':...' expand='true'>
+BEGIN_ARG_ACTION<fold text=':...;' expand='true'>
 	:	'[' {handleBeginArgAction();}
 	;</fold>
 
@@ -122,52 +122,52 @@ BEGIN_ARG_ACTION<fold text=':...' expand='true'>
 // their option block, as this is teh easiest way to parse it separate
 // to an ACTION block, despite it usingthe same {} delimiters.
 //</fold>
-OPTIONS<fold text=':...' expand='true'>      : 'options' [ \t\f\n\r]* '{'  ;</fold>
-TOKENS<fold text=':...' expand='true'>		 : 'tokens'  [ \t\f\n\r]* '{'  ;</fold>
+<fold text='OPTIONS, TOKENS' expand='true'>OPTIONS      : 'options' [ \t\f\n\r]* '{'  ;
+TOKENS		 : 'tokens'  [ \t\f\n\r]* '{'  ;</fold>
 
-IMPORT<fold text=':...' expand='true'>       : 'import'               ;</fold>
-FRAGMENT<fold text=':...' expand='true'>     : 'fragment'             ;</fold>
-LEXER<fold text=':...' expand='true'>        : 'lexer'                ;</fold>
-PARSER<fold text=':...' expand='true'>       : 'parser'               ;</fold>
-GRAMMAR<fold text=':...' expand='true'>      : 'grammar'              ;</fold>
-PROTECTED<fold text=':...' expand='true'>    : 'protected'            ;</fold>
-PUBLIC<fold text=':...' expand='true'>       : 'public'               ;</fold>
-PRIVATE<fold text=':...' expand='true'>      : 'private'              ;</fold>
-RETURNS<fold text=':...' expand='true'>      : 'returns'              ;</fold>
-LOCALS<fold text=':...' expand='true'>       : 'locals'               ;</fold>
-THROWS<fold text=':...' expand='true'>       : 'throws'               ;</fold>
-CATCH<fold text=':...' expand='true'>        : 'catch'                ;</fold>
-FINALLY<fold text=':...' expand='true'>      : 'finally'              ;</fold>
-MODE<fold text=':...' expand='true'>         : 'mode'                 ;</fold>
+<fold text='IMPORT, FRAGMENT, LEXER, PARSER, GRAMMAR, PROTECTED, PUBLIC, PRIVATE, RETURNS, LOCALS, THROWS, CATCH, FINALLY, MODE' expand='true'>IMPORT       : 'import'               ;
+FRAGMENT     : 'fragment'             ;
+LEXER        : 'lexer'                ;
+PARSER       : 'parser'               ;
+GRAMMAR      : 'grammar'              ;
+PROTECTED    : 'protected'            ;
+PUBLIC       : 'public'               ;
+PRIVATE      : 'private'              ;
+RETURNS      : 'returns'              ;
+LOCALS       : 'locals'               ;
+THROWS       : 'throws'               ;
+CATCH        : 'catch'                ;
+FINALLY      : 'finally'              ;
+MODE         : 'mode'                 ;</fold>
 
-COLON<fold text=':...' expand='true'>        : ':'                    ;</fold>
-COLONCOLON<fold text=':...' expand='true'>   : '::'                   ;</fold>
-COMMA<fold text=':...' expand='true'>        : ','                    ;</fold>
-SEMI<fold text=':...' expand='true'>         : ';'                    ;</fold>
-LPAREN<fold text=':...' expand='true'>       : '('                    ;</fold>
-RPAREN<fold text=':...' expand='true'>       : ')'                    ;</fold>
-RARROW<fold text=':...' expand='true'>       : '->'                   ;</fold>
-LT<fold text=':...' expand='true'>           : '<'                    ;</fold>
-GT<fold text=':...' expand='true'>           : '>'                    ;</fold>
-ASSIGN<fold text=':...' expand='true'>       : '='                    ;</fold>
-QUESTION<fold text=':...' expand='true'>     : '?'                    ;</fold>
-STAR<fold text=':...' expand='true'>         : '*'                    ;</fold>
-PLUS<fold text=':...' expand='true'>         : '+'                    ;</fold>
-PLUS_ASSIGN<fold text=':...' expand='true'>  : '+='                   ;</fold>
-OR<fold text=':...' expand='true'>           : '|'                    ;</fold>
-DOLLAR<fold text=':...' expand='true'>       : '$'                    ;</fold>
-DOT<fold text=':...' expand='true'>		     : '.'                    ;</fold>
-RANGE<fold text=':...' expand='true'>        : '..'                   ;</fold>
-AT<fold text=':...' expand='true'>           : '@'                    ;</fold>
-POUND<fold text=':...' expand='true'>        : '#'                    ;</fold>
-NOT<fold text=':...' expand='true'>          : '~'                    ;</fold>
-RBRACE<fold text=':...' expand='true'>       : '}'                    ;</fold>
+<fold text='COLON, COLONCOLON, COMMA, SEMI, LPAREN, RPAREN, RARROW, LT, GT, ASSIGN, QUESTION, STAR, PLUS, PLUS_ASSIGN, OR, DOLLAR, DOT, RANGE, AT, POUND, NOT, RBRACE' expand='true'>COLON        : ':'                    ;
+COLONCOLON   : '::'                   ;
+COMMA        : ','                    ;
+SEMI         : ';'                    ;
+LPAREN       : '('                    ;
+RPAREN       : ')'                    ;
+RARROW       : '->'                   ;
+LT           : '<'                    ;
+GT           : '>'                    ;
+ASSIGN       : '='                    ;
+QUESTION     : '?'                    ;
+STAR         : '*'                    ;
+PLUS         : '+'                    ;
+PLUS_ASSIGN  : '+='                   ;
+OR           : '|'                    ;
+DOLLAR       : '$'                    ;
+DOT		     : '.'                    ;
+RANGE        : '..'                   ;
+AT           : '@'                    ;
+POUND        : '#'                    ;
+NOT          : '~'                    ;
+RBRACE       : '}'                    ;</fold>
 
 <fold text='...' expand='true'>/** Allow unicode rule/token names */</fold>
-ID<fold text=':...' expand='true'>	:	NameStartChar NameChar*;</fold>
+ID<fold text=':...;' expand='true'>	:	NameStartChar NameChar*;</fold>
 
 fragment
-NameChar<fold text=':...' expand='true'>
+NameChar<fold text=':...;' expand='true'>
 	:   NameStartChar
 	|   '0'..'9'
 	|   '_'
@@ -177,7 +177,7 @@ NameChar<fold text=':...' expand='true'>
 	;</fold>
 
 fragment
-NameStartChar<fold text=':...' expand='true'>
+NameStartChar<fold text=':...;' expand='true'>
 	:   'A'..'Z'
 	|   'a'..'z'
 	|   '\u00C0'..'\u00D6'
@@ -193,25 +193,25 @@ NameStartChar<fold text=':...' expand='true'>
 	|   '\uFDF0'..'\uFFFD'
 	;</fold> <fold text='//...' expand='true'>// ignores | ['\u10000-'\uEFFFF] ;</fold>
 
-INT<fold text=':...' expand='true'>	: [0-9]+
+INT<fold text=':...;' expand='true'>	: [0-9]+
 	;</fold>
 
 <fold text='//...' expand='true'>// ANTLR makes no distinction between a single character literal and a
 // multi-character string. All literals are single quote delimited and
 // may contain unicode escape sequences of the form \uxxxx, where x
 // is a valid hexadecimal number (as per Java basically).</fold>
-STRING_LITERAL<fold text=':...' expand='true'>
+STRING_LITERAL<fold text=':...;' expand='true'>
 	:  '\'' (ESC_SEQ | ~['\r\n\\])* '\''
 	;</fold>
 
-UNTERMINATED_STRING_LITERAL<fold text=':...' expand='true'>
+UNTERMINATED_STRING_LITERAL<fold text=':...;' expand='true'>
 	:  '\'' (ESC_SEQ | ~['\r\n\\])*
 	;</fold>
 
 <fold text='//...' expand='true'>// Any kind of escaped character that we can embed within ANTLR
 // literal strings.</fold>
 fragment
-ESC_SEQ<fold text=':...' expand='true'>
+ESC_SEQ<fold text=':...;' expand='true'>
 	:	'\\'
 		(	<fold text='//...' expand='true'>// The standard escaped character set such as tab, newline, etc.</fold>
 			[btnfr"'\\]
@@ -225,14 +225,14 @@ ESC_SEQ<fold text=':...' expand='true'>
 	;</fold>
 
 fragment
-UNICODE_ESC<fold text=':...' expand='true'>
+UNICODE_ESC<fold text=':...;' expand='true'>
     :   'u' (HEX_DIGIT (HEX_DIGIT (HEX_DIGIT HEX_DIGIT?)?)?)?
     ;</fold>
 
 fragment
-HEX_DIGIT<fold text=':...' expand='true'> : [0-9a-fA-F]	;</fold>
+HEX_DIGIT<fold text=':...;' expand='true'> : [0-9a-fA-F]	;</fold>
 
-WS<fold text=':...' expand='true'>  :	[ \t\r\n\f]+ -> channel(HIDDEN)	;</fold>
+WS<fold text=':...;' expand='true'>  :	[ \t\r\n\f]+ -> channel(HIDDEN)	;</fold>
 
 <fold text='//...' expand='true'>// Many language targets use {} as block delimiters and so we
 // must recursively match {} delimited blocks to balance the
@@ -241,7 +241,7 @@ WS<fold text=':...' expand='true'>  :	[ \t\r\n\f]+ -> channel(HIDDEN)	;</fold>
 // that they are delimited by ' or " and so consume these
 // in their own alts so as not to inadvertantly match {}.</fold>
 
-ACTION<fold text=':...' expand='true'>
+ACTION<fold text=':...;' expand='true'>
 	:	'{'
 		(	ACTION
 		|	ACTION_ESCAPE
@@ -255,17 +255,17 @@ ACTION<fold text=':...' expand='true'>
 	;</fold>
 
 fragment
-ACTION_ESCAPE<fold text=':...' expand='true'>
+ACTION_ESCAPE<fold text=':...;' expand='true'>
 		:   '\\' .
 		;</fold>
 
 fragment
-ACTION_STRING_LITERAL<fold text=':...' expand='true'>
+ACTION_STRING_LITERAL<fold text=':...;' expand='true'>
         :	'"' (ACTION_ESCAPE | ~["\\])* '"'
         ;</fold>
 
 fragment
-ACTION_CHAR_LITERAL<fold text=':...' expand='true'>
+ACTION_CHAR_LITERAL<fold text=':...;' expand='true'>
         :	'\'' (ACTION_ESCAPE | ~['\\])* '\''
         ;</fold>
 
@@ -280,54 +280,54 @@ ACTION_CHAR_LITERAL<fold text=':...' expand='true'>
 // but we will not try to analyse or code generate from a file with lexical
 // errors.
 //</fold>
-ERRCHAR<fold text=':...' expand='true'>
+ERRCHAR<fold text=':...;' expand='true'>
 	:	.	-> channel(HIDDEN)
 	;</fold>
 
 mode ArgAction; <fold text='//...' expand='true'>// E.g., [int x, List<String> a[]]</fold>
 
-	NESTED_ARG_ACTION<fold text=':...' expand='true'>
+	NESTED_ARG_ACTION<fold text=':...;' expand='true'>
 		:	'['                         -> more, pushMode(ArgAction)
 		;</fold>
 
-	ARG_ACTION_ESCAPE<fold text=':...' expand='true'>
+	ARG_ACTION_ESCAPE<fold text=':...;' expand='true'>
 		:   '\\' .                      -> more
 		;</fold>
 
-    ARG_ACTION_STRING_LITERAL<fold text=':...' expand='true'>
+    ARG_ACTION_STRING_LITERAL<fold text=':...;' expand='true'>
         :	('"' ('\\' . | ~["\\])* '"')-> more
         ;</fold>
 
-    ARG_ACTION_CHAR_LITERAL<fold text=':...' expand='true'>
+    ARG_ACTION_CHAR_LITERAL<fold text=':...;' expand='true'>
         :	('"' '\\' . | ~["\\] '"')   -> more
         ;</fold>
 
-    ARG_ACTION<fold text=':...' expand='true'>
+    ARG_ACTION<fold text=':...;' expand='true'>
 		:   ']'                         -> popMode
 		;</fold>
 
-	UNTERMINATED_ARG_ACTION<fold text=':...' expand='true'> <fold text='//...' expand='true'>// added this to return non-EOF token type here. EOF did something weird</fold>
+	UNTERMINATED_ARG_ACTION<fold text=':...;' expand='true'> <fold text='//...' expand='true'>// added this to return non-EOF token type here. EOF did something weird</fold>
 		:	EOF							-> popMode
 		;</fold>
 
-    ARG_ACTION_CHAR<fold text=':...' expand='true'> <fold text='//...' expand='true'>// must be last</fold>
+    ARG_ACTION_CHAR<fold text=':...;' expand='true'> <fold text='//...' expand='true'>// must be last</fold>
         :   .                           -> more
         ;</fold>
 
 
 mode LexerCharSet;
 
-	LEXER_CHAR_SET_BODY<fold text=':...' expand='true'>
+	LEXER_CHAR_SET_BODY<fold text=':...;' expand='true'>
 		:	(	~[\]\\]
 			|	'\\' .
 			)
                                         -> more
 		;</fold>
 
-	LEXER_CHAR_SET<fold text=':...' expand='true'>
+	LEXER_CHAR_SET<fold text=':...;' expand='true'>
 		:   ']'                         -> popMode
 		;</fold>
 
-	UNTERMINATED_CHAR_SET<fold text=':...' expand='true'>
+	UNTERMINATED_CHAR_SET<fold text=':...;' expand='true'>
 		:	EOF							-> popMode
 		;</fold>

--- a/test/testData/grammars/folding/ANTLRv4Lexer.folding.g4
+++ b/test/testData/grammars/folding/ANTLRv4Lexer.folding.g4
@@ -1,0 +1,333 @@
+<fold text='...' expand='false'>/*
+ * [The "BSD license"]
+ *  Copyright (c) 2014 Terence Parr
+ *  Copyright (c) 2014 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</fold>
+
+/** A grammar for ANTLR v4 tokens */
+lexer grammar ANTLRv4Lexer;
+
+tokens <fold text='...' expand='false'>{
+	TOKEN_REF,
+	RULE_REF,
+	LEXER_CHAR_SET
+}</fold>
+
+@members <fold text='{...}' expand='false'>{
+	/** Track whether we are inside of a rule and whether it is lexical parser.
+	 *  _currentRuleType==Token.INVALID_TYPE means that we are outside of a rule.
+	 *  At the first sign of a rule name reference and _currentRuleType==invalid,
+	 *  we can assume that we are starting a parser rule. Similarly, seeing
+	 *  a token reference when not already in rule means starting a token
+	 *  rule. The terminating ';' of a rule, flips this back to invalid type.
+	 *
+	 *  This is not perfect logic but works. For example, "grammar T;" means
+	 *  that we start and stop a lexical rule for the "T;". Dangerous but works.
+	 *
+	 *  The whole point of this state information is to distinguish
+	 *  between [..arg actions..] and [charsets]. Char sets can only occur in
+	 *  lexical rules and arg actions cannot occur.
+	 */
+	private int _currentRuleType = Token.INVALID_TYPE;
+
+	public int getCurrentRuleType() {
+		return _currentRuleType;
+	}
+
+	public void setCurrentRuleType(int ruleType) {
+		this._currentRuleType = ruleType;
+	}
+
+	protected void handleBeginArgAction() {
+		if (inLexerRule()) {
+			pushMode(LexerCharSet);
+			more();
+		}
+		else {
+			pushMode(ArgAction);
+			more();
+		}
+	}
+
+	@Override
+	public Token emit() {
+		if (_type == ID) {
+			String firstChar = _input.getText(Interval.of(_tokenStartCharIndex, _tokenStartCharIndex));
+			if (Character.isUpperCase(firstChar.charAt(0))) {
+				_type = TOKEN_REF;
+			} else {
+				_type = RULE_REF;
+			}
+
+			if (_currentRuleType == Token.INVALID_TYPE) { // if outside of rule def
+				_currentRuleType = _type;                 // set to inside lexer or parser rule
+			}
+		}
+		else if (_type == SEMI) {                  // exit rule def
+			_currentRuleType = Token.INVALID_TYPE;
+		}
+
+		return super.emit();
+	}
+
+	private boolean inLexerRule() {
+		return _currentRuleType == TOKEN_REF;
+	}
+	private boolean inParserRule() { // not used, but added for clarity
+		return _currentRuleType == RULE_REF;
+	}
+}</fold>
+
+DOC_COMMENT<fold text=':...' expand='true'>
+	:	'/**' .*? ('*/' | EOF)
+	;</fold>
+
+BLOCK_COMMENT<fold text=':...' expand='true'>
+	:	'/*' .*? ('*/' | EOF)  -> channel(HIDDEN)
+	;</fold>
+
+LINE_COMMENT<fold text=':...' expand='true'>
+	:	'//' ~[\r\n]*  -> channel(HIDDEN)
+	;</fold>
+
+BEGIN_ARG_ACTION<fold text=':...' expand='true'>
+	:	'[' {handleBeginArgAction();}
+	;</fold>
+
+<fold text='//...' expand='true'>// OPTIONS and TOKENS must also consume the opening brace that captures
+// their option block, as this is teh easiest way to parse it separate
+// to an ACTION block, despite it usingthe same {} delimiters.
+//</fold>
+OPTIONS<fold text=':...' expand='true'>      : 'options' [ \t\f\n\r]* '{'  ;</fold>
+TOKENS<fold text=':...' expand='true'>		 : 'tokens'  [ \t\f\n\r]* '{'  ;</fold>
+
+IMPORT<fold text=':...' expand='true'>       : 'import'               ;</fold>
+FRAGMENT<fold text=':...' expand='true'>     : 'fragment'             ;</fold>
+LEXER<fold text=':...' expand='true'>        : 'lexer'                ;</fold>
+PARSER<fold text=':...' expand='true'>       : 'parser'               ;</fold>
+GRAMMAR<fold text=':...' expand='true'>      : 'grammar'              ;</fold>
+PROTECTED<fold text=':...' expand='true'>    : 'protected'            ;</fold>
+PUBLIC<fold text=':...' expand='true'>       : 'public'               ;</fold>
+PRIVATE<fold text=':...' expand='true'>      : 'private'              ;</fold>
+RETURNS<fold text=':...' expand='true'>      : 'returns'              ;</fold>
+LOCALS<fold text=':...' expand='true'>       : 'locals'               ;</fold>
+THROWS<fold text=':...' expand='true'>       : 'throws'               ;</fold>
+CATCH<fold text=':...' expand='true'>        : 'catch'                ;</fold>
+FINALLY<fold text=':...' expand='true'>      : 'finally'              ;</fold>
+MODE<fold text=':...' expand='true'>         : 'mode'                 ;</fold>
+
+COLON<fold text=':...' expand='true'>        : ':'                    ;</fold>
+COLONCOLON<fold text=':...' expand='true'>   : '::'                   ;</fold>
+COMMA<fold text=':...' expand='true'>        : ','                    ;</fold>
+SEMI<fold text=':...' expand='true'>         : ';'                    ;</fold>
+LPAREN<fold text=':...' expand='true'>       : '('                    ;</fold>
+RPAREN<fold text=':...' expand='true'>       : ')'                    ;</fold>
+RARROW<fold text=':...' expand='true'>       : '->'                   ;</fold>
+LT<fold text=':...' expand='true'>           : '<'                    ;</fold>
+GT<fold text=':...' expand='true'>           : '>'                    ;</fold>
+ASSIGN<fold text=':...' expand='true'>       : '='                    ;</fold>
+QUESTION<fold text=':...' expand='true'>     : '?'                    ;</fold>
+STAR<fold text=':...' expand='true'>         : '*'                    ;</fold>
+PLUS<fold text=':...' expand='true'>         : '+'                    ;</fold>
+PLUS_ASSIGN<fold text=':...' expand='true'>  : '+='                   ;</fold>
+OR<fold text=':...' expand='true'>           : '|'                    ;</fold>
+DOLLAR<fold text=':...' expand='true'>       : '$'                    ;</fold>
+DOT<fold text=':...' expand='true'>		     : '.'                    ;</fold>
+RANGE<fold text=':...' expand='true'>        : '..'                   ;</fold>
+AT<fold text=':...' expand='true'>           : '@'                    ;</fold>
+POUND<fold text=':...' expand='true'>        : '#'                    ;</fold>
+NOT<fold text=':...' expand='true'>          : '~'                    ;</fold>
+RBRACE<fold text=':...' expand='true'>       : '}'                    ;</fold>
+
+<fold text='...' expand='true'>/** Allow unicode rule/token names */</fold>
+ID<fold text=':...' expand='true'>	:	NameStartChar NameChar*;</fold>
+
+fragment
+NameChar<fold text=':...' expand='true'>
+	:   NameStartChar
+	|   '0'..'9'
+	|   '_'
+	|   '\u00B7'
+	|   '\u0300'..'\u036F'
+	|   '\u203F'..'\u2040'
+	;</fold>
+
+fragment
+NameStartChar<fold text=':...' expand='true'>
+	:   'A'..'Z'
+	|   'a'..'z'
+	|   '\u00C0'..'\u00D6'
+	|   '\u00D8'..'\u00F6'
+	|   '\u00F8'..'\u02FF'
+	|   '\u0370'..'\u037D'
+	|   '\u037F'..'\u1FFF'
+	|   '\u200C'..'\u200D'
+	|   '\u2070'..'\u218F'
+	|   '\u2C00'..'\u2FEF'
+	|   '\u3001'..'\uD7FF'
+	|   '\uF900'..'\uFDCF'
+	|   '\uFDF0'..'\uFFFD'
+	;</fold> <fold text='//...' expand='true'>// ignores | ['\u10000-'\uEFFFF] ;</fold>
+
+INT<fold text=':...' expand='true'>	: [0-9]+
+	;</fold>
+
+<fold text='//...' expand='true'>// ANTLR makes no distinction between a single character literal and a
+// multi-character string. All literals are single quote delimited and
+// may contain unicode escape sequences of the form \uxxxx, where x
+// is a valid hexadecimal number (as per Java basically).</fold>
+STRING_LITERAL<fold text=':...' expand='true'>
+	:  '\'' (ESC_SEQ | ~['\r\n\\])* '\''
+	;</fold>
+
+UNTERMINATED_STRING_LITERAL<fold text=':...' expand='true'>
+	:  '\'' (ESC_SEQ | ~['\r\n\\])*
+	;</fold>
+
+<fold text='//...' expand='true'>// Any kind of escaped character that we can embed within ANTLR
+// literal strings.</fold>
+fragment
+ESC_SEQ<fold text=':...' expand='true'>
+	:	'\\'
+		(	<fold text='//...' expand='true'>// The standard escaped character set such as tab, newline, etc.</fold>
+			[btnfr"'\\]
+		|	<fold text='//...' expand='true'>// A Java style Unicode escape sequence</fold>
+			UNICODE_ESC
+		|	<fold text='//...' expand='true'>// Invalid escape</fold>
+			.
+		|	<fold text='//...' expand='true'>// Invalid escape at end of file</fold>
+			EOF
+		)
+	;</fold>
+
+fragment
+UNICODE_ESC<fold text=':...' expand='true'>
+    :   'u' (HEX_DIGIT (HEX_DIGIT (HEX_DIGIT HEX_DIGIT?)?)?)?
+    ;</fold>
+
+fragment
+HEX_DIGIT<fold text=':...' expand='true'> : [0-9a-fA-F]	;</fold>
+
+WS<fold text=':...' expand='true'>  :	[ \t\r\n\f]+ -> channel(HIDDEN)	;</fold>
+
+<fold text='//...' expand='true'>// Many language targets use {} as block delimiters and so we
+// must recursively match {} delimited blocks to balance the
+// braces. Additionally, we must make some assumptions about
+// literal string representation in the target language. We assume
+// that they are delimited by ' or " and so consume these
+// in their own alts so as not to inadvertantly match {}.</fold>
+
+ACTION<fold text=':...' expand='true'>
+	:	'{'
+		(	ACTION
+		|	ACTION_ESCAPE
+        |	ACTION_STRING_LITERAL
+        |	ACTION_CHAR_LITERAL
+        |	'/*' .*? '*/' <fold text='//...' expand='true'>// ('*/' | EOF)</fold>
+        |	'//' ~[\r\n]*
+        |	.
+		)*?
+		('}'|EOF)
+	;</fold>
+
+fragment
+ACTION_ESCAPE<fold text=':...' expand='true'>
+		:   '\\' .
+		;</fold>
+
+fragment
+ACTION_STRING_LITERAL<fold text=':...' expand='true'>
+        :	'"' (ACTION_ESCAPE | ~["\\])* '"'
+        ;</fold>
+
+fragment
+ACTION_CHAR_LITERAL<fold text=':...' expand='true'>
+        :	'\'' (ACTION_ESCAPE | ~['\\])* '\''
+        ;</fold>
+
+<fold text='//...' expand='true'>// -----------------
+// Illegal Character
+//
+// This is an illegal character trap which is always the last rule in the
+// lexer specification. It matches a single character of any value and being
+// the last rule in the file will match when no other rule knows what to do
+// about the character. It is reported as an error but is not passed on to the
+// parser. This means that the parser to deal with the gramamr file anyway
+// but we will not try to analyse or code generate from a file with lexical
+// errors.
+//</fold>
+ERRCHAR<fold text=':...' expand='true'>
+	:	.	-> channel(HIDDEN)
+	;</fold>
+
+mode ArgAction; <fold text='//...' expand='true'>// E.g., [int x, List<String> a[]]</fold>
+
+	NESTED_ARG_ACTION<fold text=':...' expand='true'>
+		:	'['                         -> more, pushMode(ArgAction)
+		;</fold>
+
+	ARG_ACTION_ESCAPE<fold text=':...' expand='true'>
+		:   '\\' .                      -> more
+		;</fold>
+
+    ARG_ACTION_STRING_LITERAL<fold text=':...' expand='true'>
+        :	('"' ('\\' . | ~["\\])* '"')-> more
+        ;</fold>
+
+    ARG_ACTION_CHAR_LITERAL<fold text=':...' expand='true'>
+        :	('"' '\\' . | ~["\\] '"')   -> more
+        ;</fold>
+
+    ARG_ACTION<fold text=':...' expand='true'>
+		:   ']'                         -> popMode
+		;</fold>
+
+	UNTERMINATED_ARG_ACTION<fold text=':...' expand='true'> <fold text='//...' expand='true'>// added this to return non-EOF token type here. EOF did something weird</fold>
+		:	EOF							-> popMode
+		;</fold>
+
+    ARG_ACTION_CHAR<fold text=':...' expand='true'> <fold text='//...' expand='true'>// must be last</fold>
+        :   .                           -> more
+        ;</fold>
+
+
+mode LexerCharSet;
+
+	LEXER_CHAR_SET_BODY<fold text=':...' expand='true'>
+		:	(	~[\]\\]
+			|	'\\' .
+			)
+                                        -> more
+		;</fold>
+
+	LEXER_CHAR_SET<fold text=':...' expand='true'>
+		:   ']'                         -> popMode
+		;</fold>
+
+	UNTERMINATED_CHAR_SET<fold text=':...' expand='true'>
+		:	EOF							-> popMode
+		;</fold>

--- a/test/testData/grammars/folding/ANTLRv4Lexer.folding.g4
+++ b/test/testData/grammars/folding/ANTLRv4Lexer.folding.g4
@@ -28,7 +28,7 @@
  *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */</fold>
 
-/** A grammar for ANTLR v4 tokens */
+<fold text='...' expand='true'>/** A grammar for ANTLR v4 tokens */</fold>
 lexer grammar ANTLRv4Lexer;
 
 tokens <fold text='...' expand='false'>{

--- a/test/testData/grammars/folding/ANTLRv4Parser.folding.g4
+++ b/test/testData/grammars/folding/ANTLRv4Parser.folding.g4
@@ -28,8 +28,8 @@
  *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */</fold>
 
-/** A grammar for ANTLR v4 written in ANTLR v4.
-*/
+<fold text='...' expand='true'>/** A grammar for ANTLR v4 written in ANTLR v4.
+*/</fold>
 parser grammar ANTLRv4Parser;
 
 options {<fold text='...' expand='true'>

--- a/test/testData/grammars/folding/ANTLRv4Parser.folding.g4
+++ b/test/testData/grammars/folding/ANTLRv4Parser.folding.g4
@@ -1,0 +1,366 @@
+<fold text='...' expand='false'>/*
+ * [The "BSD license"]
+ *  Copyright (c) 2013 Terence Parr
+ *  Copyright (c) 2013 Sam Harwell
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. The name of the author may not be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ *  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ *  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ *  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</fold>
+
+/** A grammar for ANTLR v4 written in ANTLR v4.
+*/
+parser grammar ANTLRv4Parser;
+
+options {<fold text='...' expand='true'>
+	tokenVocab=ANTLRv4Lexer;
+}</fold>
+
+<fold text='//...' expand='true'>// The main entry point for parsing a v4 grammar.</fold>
+grammarSpec<fold text=':...' expand='true'>
+	:	DOC_COMMENT?
+		grammarType id SEMI
+		prequelConstruct*
+		rules
+		modeSpec*
+		EOF
+	;</fold>
+
+grammarType<fold text=':...' expand='true'>
+	:	(	LEXER GRAMMAR
+		|	PARSER GRAMMAR
+		|	GRAMMAR
+		)
+	;</fold>
+
+<fold text='//...' expand='true'>// This is the list of all constructs that can be declared before
+// the set of rules that compose the grammar, and is invoked 0..n
+// times by the grammarPrequel rule.</fold>
+prequelConstruct<fold text=':...' expand='true'>
+	:	optionsSpec
+	|	delegateGrammars
+	|	tokensSpec
+	|	action
+	;</fold>
+
+<fold text='//...' expand='true'>// A list of options that affect analysis and/or code generation</fold>
+optionsSpec<fold text=':...' expand='true'>
+	:	OPTIONS (option SEMI)* RBRACE
+	;</fold>
+
+option<fold text=':...' expand='true'>
+	:	id ASSIGN optionValue
+	;</fold>
+
+optionValue<fold text=':...' expand='true'>
+	:	id (DOT id)*
+	|	STRING_LITERAL
+	|	ACTION
+	|	INT
+	;</fold>
+
+delegateGrammars<fold text=':...' expand='true'>
+	:	IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
+	;</fold>
+
+delegateGrammar<fold text=':...' expand='true'>
+	:	id ASSIGN id
+	|	id
+	;</fold>
+
+tokensSpec<fold text=':...' expand='true'>
+	:	TOKENS id (COMMA id)* COMMA? RBRACE
+	;</fold>
+
+<fold text='...' expand='true'>/** Match stuff like @parser::members {int i;} */</fold>
+action<fold text=':...' expand='true'>
+	:	AT (actionScopeName COLONCOLON)? id ACTION
+	;</fold>
+
+<fold text='...' expand='true'>/** Sometimes the scope names will collide with keywords; allow them as
+ *  ids for action scopes.
+ */</fold>
+actionScopeName<fold text=':...' expand='true'>
+	:	id
+	|	LEXER
+	|	PARSER
+	;</fold>
+
+modeSpec<fold text=':...' expand='true'>
+	:	MODE id SEMI lexerRule*
+	;</fold>
+
+rules<fold text=':...' expand='true'>
+	:	ruleSpec*
+	;</fold>
+
+ruleSpec<fold text=':...' expand='true'>
+	:	parserRuleSpec
+	|	lexerRule
+	;</fold>
+
+parserRuleSpec<fold text=':...' expand='true'>
+	:	DOC_COMMENT?
+        ruleModifiers? RULE_REF ARG_ACTION?
+        ruleReturns? throwsSpec? localsSpec?
+		rulePrequel*
+		COLON
+            ruleBlock
+		SEMI
+		exceptionGroup
+	;</fold>
+
+exceptionGroup<fold text=':...' expand='true'>
+	:	exceptionHandler* finallyClause?
+	;</fold>
+
+exceptionHandler<fold text=':...' expand='true'>
+	:	CATCH ARG_ACTION ACTION
+	;</fold>
+
+finallyClause<fold text=':...' expand='true'>
+	:	FINALLY ACTION
+	;</fold>
+
+rulePrequel<fold text=':...' expand='true'>
+	:	optionsSpec
+	|	ruleAction
+	;</fold>
+
+ruleReturns<fold text=':...' expand='true'>
+	:	RETURNS ARG_ACTION
+	;</fold>
+
+throwsSpec<fold text=':...' expand='true'>
+	:	THROWS id (COMMA id)*
+	;</fold>
+
+localsSpec<fold text=':...' expand='true'>
+	:	LOCALS ARG_ACTION
+	;</fold>
+
+<fold text='...' expand='true'>/** Match stuff like @init {int i;} */</fold>
+ruleAction<fold text=':...' expand='true'>
+	:	AT id ACTION
+	;</fold>
+
+ruleModifiers<fold text=':...' expand='true'>
+	:	ruleModifier+
+	;</fold>
+
+<fold text='//...' expand='true'>// An individual access modifier for a rule. The 'fragment' modifier
+// is an internal indication for lexer rules that they do not match
+// from the input but are like subroutines for other lexer rules to
+// reuse for certain lexical patterns. The other modifiers are passed
+// to the code generation templates and may be ignored by the template
+// if they are of no use in that language.</fold>
+ruleModifier<fold text=':...' expand='true'>
+	:	PUBLIC
+	|	PRIVATE
+	|	PROTECTED
+	|	FRAGMENT
+	;</fold>
+
+ruleBlock<fold text=':...' expand='true'>
+	:	ruleAltList
+	;</fold>
+
+ruleAltList<fold text=':...' expand='true'>
+	:	labeledAlt (OR labeledAlt)*
+	;</fold>
+
+labeledAlt<fold text=':...' expand='true'>
+	:	alternative (POUND id)?
+	;</fold>
+
+lexerRule<fold text=':...' expand='true'>
+	:	DOC_COMMENT? FRAGMENT?
+		TOKEN_REF COLON lexerRuleBlock SEMI
+	;</fold>
+
+lexerRuleBlock<fold text=':...' expand='true'>
+	:	lexerAltList
+	;</fold>
+
+lexerAltList<fold text=':...' expand='true'>
+	:	lexerAlt (OR lexerAlt)*
+	;</fold>
+
+lexerAlt<fold text=':...' expand='true'>
+	:	lexerElements lexerCommands?
+	|
+	;</fold>
+
+lexerElements<fold text=':...' expand='true'>
+	:	lexerElement+
+	;</fold>
+
+lexerElement<fold text=':...' expand='true'>
+	:	labeledLexerElement ebnfSuffix?
+	|	lexerAtom ebnfSuffix?
+	|	lexerBlock ebnfSuffix?
+	|	ACTION QUESTION? <fold text='//...' expand='true'>// actions only allowed at end of outer alt actually,
+                         // but preds can be anywhere</fold>
+	;</fold>
+
+labeledLexerElement<fold text=':...' expand='true'>
+	:	id (ASSIGN|PLUS_ASSIGN)
+		(	lexerAtom
+		|	block
+		)
+	;</fold>
+
+lexerBlock<fold text=':...' expand='true'>
+	:	LPAREN lexerAltList RPAREN
+	;</fold>
+
+<fold text='//...' expand='true'>// E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop</fold>
+lexerCommands<fold text=':...' expand='true'>
+	:	RARROW lexerCommand (COMMA lexerCommand)*
+	;</fold>
+
+lexerCommand<fold text=':...' expand='true'>
+	:	lexerCommandName LPAREN lexerCommandExpr RPAREN
+	|	lexerCommandName
+	;</fold>
+
+lexerCommandName<fold text=':...' expand='true'>
+	:	id
+	|	MODE
+	;</fold>
+
+lexerCommandExpr<fold text=':...' expand='true'>
+	:	id
+	|	INT
+	;</fold>
+
+altList<fold text=':...' expand='true'>
+	:	alternative (OR alternative)*
+	;</fold>
+
+alternative<fold text=':...' expand='true'>
+	:	elementOptions? element*
+	;</fold>
+
+element<fold text=':...' expand='true'>
+	:	labeledElement
+		(	ebnfSuffix
+		|
+		)
+	|	atom
+		(	ebnfSuffix
+		|
+		)
+	|	ebnf
+	|	ACTION QUESTION? <fold text='//...' expand='true'>// SEMPRED is ACTION followed by QUESTION</fold>
+	;</fold>
+
+labeledElement<fold text=':...' expand='true'>
+	:	id (ASSIGN|PLUS_ASSIGN)
+		(	atom
+		|	block
+		)
+	;</fold>
+
+ebnf<fold text=':...' expand='true'>:	block blockSuffix?
+	;</fold>
+
+blockSuffix<fold text=':...' expand='true'>
+	:	ebnfSuffix <fold text='//...' expand='true'>// Standard EBNF</fold>
+	;</fold>
+
+ebnfSuffix<fold text=':...' expand='true'>
+	:	QUESTION QUESTION?
+  	|	STAR QUESTION?
+   	|	PLUS QUESTION?
+	;</fold>
+
+lexerAtom<fold text=':...' expand='true'>
+	:	range
+	|	terminal
+	|	RULE_REF
+	|	notSet
+	|	LEXER_CHAR_SET
+	|	DOT elementOptions?
+	;</fold>
+
+atom<fold text=':...' expand='true'>
+	:	range <fold text='//...' expand='true'>// Range x..y - only valid in lexers</fold>
+	|	terminal
+	|	ruleref
+	|	notSet
+	|	DOT elementOptions?
+	;</fold>
+
+notSet<fold text=':...' expand='true'>
+	:	NOT setElement
+	|	NOT blockSet
+	;</fold>
+
+blockSet<fold text=':...' expand='true'>
+	:	LPAREN setElement (OR setElement)* RPAREN
+	;</fold>
+
+setElement<fold text=':...' expand='true'>
+	:	TOKEN_REF elementOptions?
+	|	STRING_LITERAL elementOptions?
+	|	range
+	|	LEXER_CHAR_SET
+	;</fold>
+
+block<fold text=':...' expand='true'>
+	:	LPAREN
+		( optionsSpec? ruleAction* COLON )?
+		altList
+		RPAREN
+	;</fold>
+
+ruleref<fold text=':...' expand='true'>
+	:	RULE_REF ARG_ACTION? elementOptions?
+	;</fold>
+
+range<fold text=':...' expand='true'>
+	: STRING_LITERAL RANGE STRING_LITERAL
+	;</fold>
+
+terminal<fold text=':...' expand='true'>
+	:   TOKEN_REF elementOptions?
+	|   STRING_LITERAL elementOptions?
+	;</fold>
+
+<fold text='//...' expand='true'>// Terminals may be adorned with certain options when
+// reference in the grammar: TOK<,,,></fold>
+elementOptions<fold text=':...' expand='true'>
+	:	LT elementOption (COMMA elementOption)* GT
+	;</fold>
+
+elementOption<fold text=':...' expand='true'>
+	:	<fold text='//...' expand='true'>// This format indicates the default node option</fold>
+		id
+	|	<fold text='//...' expand='true'>// This format indicates option assignment</fold>
+		id ASSIGN (id | STRING_LITERAL)
+	;</fold>
+
+id<fold text=':...' expand='true'>	:	RULE_REF
+	|	TOKEN_REF
+	;</fold>

--- a/test/testData/grammars/folding/ANTLRv4Parser.folding.g4
+++ b/test/testData/grammars/folding/ANTLRv4Parser.folding.g4
@@ -37,7 +37,7 @@ options {<fold text='...' expand='true'>
 }</fold>
 
 <fold text='//...' expand='true'>// The main entry point for parsing a v4 grammar.</fold>
-grammarSpec<fold text=':...' expand='true'>
+grammarSpec<fold text=':...;' expand='true'>
 	:	DOC_COMMENT?
 		grammarType id SEMI
 		prequelConstruct*
@@ -46,7 +46,7 @@ grammarSpec<fold text=':...' expand='true'>
 		EOF
 	;</fold>
 
-grammarType<fold text=':...' expand='true'>
+grammarType<fold text=':...;' expand='true'>
 	:	(	LEXER GRAMMAR
 		|	PARSER GRAMMAR
 		|	GRAMMAR
@@ -56,7 +56,7 @@ grammarType<fold text=':...' expand='true'>
 <fold text='//...' expand='true'>// This is the list of all constructs that can be declared before
 // the set of rules that compose the grammar, and is invoked 0..n
 // times by the grammarPrequel rule.</fold>
-prequelConstruct<fold text=':...' expand='true'>
+prequelConstruct<fold text=':...;' expand='true'>
 	:	optionsSpec
 	|	delegateGrammars
 	|	tokensSpec
@@ -64,62 +64,62 @@ prequelConstruct<fold text=':...' expand='true'>
 	;</fold>
 
 <fold text='//...' expand='true'>// A list of options that affect analysis and/or code generation</fold>
-optionsSpec<fold text=':...' expand='true'>
+optionsSpec<fold text=':...;' expand='true'>
 	:	OPTIONS (option SEMI)* RBRACE
 	;</fold>
 
-option<fold text=':...' expand='true'>
+option<fold text=':...;' expand='true'>
 	:	id ASSIGN optionValue
 	;</fold>
 
-optionValue<fold text=':...' expand='true'>
+optionValue<fold text=':...;' expand='true'>
 	:	id (DOT id)*
 	|	STRING_LITERAL
 	|	ACTION
 	|	INT
 	;</fold>
 
-delegateGrammars<fold text=':...' expand='true'>
+delegateGrammars<fold text=':...;' expand='true'>
 	:	IMPORT delegateGrammar (COMMA delegateGrammar)* SEMI
 	;</fold>
 
-delegateGrammar<fold text=':...' expand='true'>
+delegateGrammar<fold text=':...;' expand='true'>
 	:	id ASSIGN id
 	|	id
 	;</fold>
 
-tokensSpec<fold text=':...' expand='true'>
+tokensSpec<fold text=':...;' expand='true'>
 	:	TOKENS id (COMMA id)* COMMA? RBRACE
 	;</fold>
 
 <fold text='...' expand='true'>/** Match stuff like @parser::members {int i;} */</fold>
-action<fold text=':...' expand='true'>
+action<fold text=':...;' expand='true'>
 	:	AT (actionScopeName COLONCOLON)? id ACTION
 	;</fold>
 
 <fold text='...' expand='true'>/** Sometimes the scope names will collide with keywords; allow them as
  *  ids for action scopes.
  */</fold>
-actionScopeName<fold text=':...' expand='true'>
+actionScopeName<fold text=':...;' expand='true'>
 	:	id
 	|	LEXER
 	|	PARSER
 	;</fold>
 
-modeSpec<fold text=':...' expand='true'>
+modeSpec<fold text=':...;' expand='true'>
 	:	MODE id SEMI lexerRule*
 	;</fold>
 
-rules<fold text=':...' expand='true'>
+rules<fold text=':...;' expand='true'>
 	:	ruleSpec*
 	;</fold>
 
-ruleSpec<fold text=':...' expand='true'>
+ruleSpec<fold text=':...;' expand='true'>
 	:	parserRuleSpec
 	|	lexerRule
 	;</fold>
 
-parserRuleSpec<fold text=':...' expand='true'>
+parserRuleSpec<fold text=':...;' expand='true'>
 	:	DOC_COMMENT?
         ruleModifiers? RULE_REF ARG_ACTION?
         ruleReturns? throwsSpec? localsSpec?
@@ -130,41 +130,41 @@ parserRuleSpec<fold text=':...' expand='true'>
 		exceptionGroup
 	;</fold>
 
-exceptionGroup<fold text=':...' expand='true'>
+exceptionGroup<fold text=':...;' expand='true'>
 	:	exceptionHandler* finallyClause?
 	;</fold>
 
-exceptionHandler<fold text=':...' expand='true'>
+exceptionHandler<fold text=':...;' expand='true'>
 	:	CATCH ARG_ACTION ACTION
 	;</fold>
 
-finallyClause<fold text=':...' expand='true'>
+finallyClause<fold text=':...;' expand='true'>
 	:	FINALLY ACTION
 	;</fold>
 
-rulePrequel<fold text=':...' expand='true'>
+rulePrequel<fold text=':...;' expand='true'>
 	:	optionsSpec
 	|	ruleAction
 	;</fold>
 
-ruleReturns<fold text=':...' expand='true'>
+ruleReturns<fold text=':...;' expand='true'>
 	:	RETURNS ARG_ACTION
 	;</fold>
 
-throwsSpec<fold text=':...' expand='true'>
+throwsSpec<fold text=':...;' expand='true'>
 	:	THROWS id (COMMA id)*
 	;</fold>
 
-localsSpec<fold text=':...' expand='true'>
+localsSpec<fold text=':...;' expand='true'>
 	:	LOCALS ARG_ACTION
 	;</fold>
 
 <fold text='...' expand='true'>/** Match stuff like @init {int i;} */</fold>
-ruleAction<fold text=':...' expand='true'>
+ruleAction<fold text=':...;' expand='true'>
 	:	AT id ACTION
 	;</fold>
 
-ruleModifiers<fold text=':...' expand='true'>
+ruleModifiers<fold text=':...;' expand='true'>
 	:	ruleModifier+
 	;</fold>
 
@@ -174,48 +174,48 @@ ruleModifiers<fold text=':...' expand='true'>
 // reuse for certain lexical patterns. The other modifiers are passed
 // to the code generation templates and may be ignored by the template
 // if they are of no use in that language.</fold>
-ruleModifier<fold text=':...' expand='true'>
+ruleModifier<fold text=':...;' expand='true'>
 	:	PUBLIC
 	|	PRIVATE
 	|	PROTECTED
 	|	FRAGMENT
 	;</fold>
 
-ruleBlock<fold text=':...' expand='true'>
+ruleBlock<fold text=':...;' expand='true'>
 	:	ruleAltList
 	;</fold>
 
-ruleAltList<fold text=':...' expand='true'>
+ruleAltList<fold text=':...;' expand='true'>
 	:	labeledAlt (OR labeledAlt)*
 	;</fold>
 
-labeledAlt<fold text=':...' expand='true'>
+labeledAlt<fold text=':...;' expand='true'>
 	:	alternative (POUND id)?
 	;</fold>
 
-lexerRule<fold text=':...' expand='true'>
+lexerRule<fold text=':...;' expand='true'>
 	:	DOC_COMMENT? FRAGMENT?
 		TOKEN_REF COLON lexerRuleBlock SEMI
 	;</fold>
 
-lexerRuleBlock<fold text=':...' expand='true'>
+lexerRuleBlock<fold text=':...;' expand='true'>
 	:	lexerAltList
 	;</fold>
 
-lexerAltList<fold text=':...' expand='true'>
+lexerAltList<fold text=':...;' expand='true'>
 	:	lexerAlt (OR lexerAlt)*
 	;</fold>
 
-lexerAlt<fold text=':...' expand='true'>
+lexerAlt<fold text=':...;' expand='true'>
 	:	lexerElements lexerCommands?
 	|
 	;</fold>
 
-lexerElements<fold text=':...' expand='true'>
+lexerElements<fold text=':...;' expand='true'>
 	:	lexerElement+
 	;</fold>
 
-lexerElement<fold text=':...' expand='true'>
+lexerElement<fold text=':...;' expand='true'>
 	:	labeledLexerElement ebnfSuffix?
 	|	lexerAtom ebnfSuffix?
 	|	lexerBlock ebnfSuffix?
@@ -223,46 +223,46 @@ lexerElement<fold text=':...' expand='true'>
                          // but preds can be anywhere</fold>
 	;</fold>
 
-labeledLexerElement<fold text=':...' expand='true'>
+labeledLexerElement<fold text=':...;' expand='true'>
 	:	id (ASSIGN|PLUS_ASSIGN)
 		(	lexerAtom
 		|	block
 		)
 	;</fold>
 
-lexerBlock<fold text=':...' expand='true'>
+lexerBlock<fold text=':...;' expand='true'>
 	:	LPAREN lexerAltList RPAREN
 	;</fold>
 
 <fold text='//...' expand='true'>// E.g., channel(HIDDEN), skip, more, mode(INSIDE), push(INSIDE), pop</fold>
-lexerCommands<fold text=':...' expand='true'>
+lexerCommands<fold text=':...;' expand='true'>
 	:	RARROW lexerCommand (COMMA lexerCommand)*
 	;</fold>
 
-lexerCommand<fold text=':...' expand='true'>
+lexerCommand<fold text=':...;' expand='true'>
 	:	lexerCommandName LPAREN lexerCommandExpr RPAREN
 	|	lexerCommandName
 	;</fold>
 
-lexerCommandName<fold text=':...' expand='true'>
+lexerCommandName<fold text=':...;' expand='true'>
 	:	id
 	|	MODE
 	;</fold>
 
-lexerCommandExpr<fold text=':...' expand='true'>
+lexerCommandExpr<fold text=':...;' expand='true'>
 	:	id
 	|	INT
 	;</fold>
 
-altList<fold text=':...' expand='true'>
+altList<fold text=':...;' expand='true'>
 	:	alternative (OR alternative)*
 	;</fold>
 
-alternative<fold text=':...' expand='true'>
+alternative<fold text=':...;' expand='true'>
 	:	elementOptions? element*
 	;</fold>
 
-element<fold text=':...' expand='true'>
+element<fold text=':...;' expand='true'>
 	:	labeledElement
 		(	ebnfSuffix
 		|
@@ -275,27 +275,27 @@ element<fold text=':...' expand='true'>
 	|	ACTION QUESTION? <fold text='//...' expand='true'>// SEMPRED is ACTION followed by QUESTION</fold>
 	;</fold>
 
-labeledElement<fold text=':...' expand='true'>
+labeledElement<fold text=':...;' expand='true'>
 	:	id (ASSIGN|PLUS_ASSIGN)
 		(	atom
 		|	block
 		)
 	;</fold>
 
-ebnf<fold text=':...' expand='true'>:	block blockSuffix?
+ebnf<fold text=':...;' expand='true'>:	block blockSuffix?
 	;</fold>
 
-blockSuffix<fold text=':...' expand='true'>
+blockSuffix<fold text=':...;' expand='true'>
 	:	ebnfSuffix <fold text='//...' expand='true'>// Standard EBNF</fold>
 	;</fold>
 
-ebnfSuffix<fold text=':...' expand='true'>
+ebnfSuffix<fold text=':...;' expand='true'>
 	:	QUESTION QUESTION?
   	|	STAR QUESTION?
    	|	PLUS QUESTION?
 	;</fold>
 
-lexerAtom<fold text=':...' expand='true'>
+lexerAtom<fold text=':...;' expand='true'>
 	:	range
 	|	terminal
 	|	RULE_REF
@@ -304,7 +304,7 @@ lexerAtom<fold text=':...' expand='true'>
 	|	DOT elementOptions?
 	;</fold>
 
-atom<fold text=':...' expand='true'>
+atom<fold text=':...;' expand='true'>
 	:	range <fold text='//...' expand='true'>// Range x..y - only valid in lexers</fold>
 	|	terminal
 	|	ruleref
@@ -312,55 +312,55 @@ atom<fold text=':...' expand='true'>
 	|	DOT elementOptions?
 	;</fold>
 
-notSet<fold text=':...' expand='true'>
+notSet<fold text=':...;' expand='true'>
 	:	NOT setElement
 	|	NOT blockSet
 	;</fold>
 
-blockSet<fold text=':...' expand='true'>
+blockSet<fold text=':...;' expand='true'>
 	:	LPAREN setElement (OR setElement)* RPAREN
 	;</fold>
 
-setElement<fold text=':...' expand='true'>
+setElement<fold text=':...;' expand='true'>
 	:	TOKEN_REF elementOptions?
 	|	STRING_LITERAL elementOptions?
 	|	range
 	|	LEXER_CHAR_SET
 	;</fold>
 
-block<fold text=':...' expand='true'>
+block<fold text=':...;' expand='true'>
 	:	LPAREN
 		( optionsSpec? ruleAction* COLON )?
 		altList
 		RPAREN
 	;</fold>
 
-ruleref<fold text=':...' expand='true'>
+ruleref<fold text=':...;' expand='true'>
 	:	RULE_REF ARG_ACTION? elementOptions?
 	;</fold>
 
-range<fold text=':...' expand='true'>
+range<fold text=':...;' expand='true'>
 	: STRING_LITERAL RANGE STRING_LITERAL
 	;</fold>
 
-terminal<fold text=':...' expand='true'>
+terminal<fold text=':...;' expand='true'>
 	:   TOKEN_REF elementOptions?
 	|   STRING_LITERAL elementOptions?
 	;</fold>
 
 <fold text='//...' expand='true'>// Terminals may be adorned with certain options when
 // reference in the grammar: TOK<,,,></fold>
-elementOptions<fold text=':...' expand='true'>
+elementOptions<fold text=':...;' expand='true'>
 	:	LT elementOption (COMMA elementOption)* GT
 	;</fold>
 
-elementOption<fold text=':...' expand='true'>
+elementOption<fold text=':...;' expand='true'>
 	:	<fold text='//...' expand='true'>// This format indicates the default node option</fold>
 		id
 	|	<fold text='//...' expand='true'>// This format indicates option assignment</fold>
 		id ASSIGN (id | STRING_LITERAL)
 	;</fold>
 
-id<fold text=':...' expand='true'>	:	RULE_REF
+id<fold text=':...;' expand='true'>	:	RULE_REF
 	|	TOKEN_REF
 	;</fold>


### PR DESCRIPTION
here is a short summary...
* traversal of grammars for folding is more directed and should be more efficient
* when a bunch of rules are on adjacent lines they get folded together
*added a folding test
* ast/psi iterables in the style of [google's FluentIterable](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/collect/FluentIterable.html)