### PR TITLE
Use control key not meta key for showing token information in life preview

### DIFF
--- a/src/java/org/antlr/intellij/plugin/preview/PreviewEditorMouseListener.java
+++ b/src/java/org/antlr/intellij/plugin/preview/PreviewEditorMouseListener.java
@@ -36,7 +36,7 @@ class PreviewEditorMouseListener implements EditorMouseListener, EditorMouseMoti
 		}
 
 		MouseEvent mouseEvent=e.getMouseEvent();
-		if ( mouseEvent.isMetaDown() ) {
+		if ( mouseEvent.isControlDown() ) {
 			inputPanel.setCursorToGrammarElement(e.getEditor().getProject(), previewState, offset);
 		}
         else if ( mouseEvent.isAltDown() ) {
@@ -59,7 +59,7 @@ class PreviewEditorMouseListener implements EditorMouseListener, EditorMouseMoti
 
 		MouseEvent mouseEvent=e.getMouseEvent();
 		InputPanel.removeTokenInfoHighlighters(editor);
-		if ( mouseEvent.isMetaDown() && previewState.parsingResult!=null ) {
+		if ( mouseEvent.isControlDown() && previewState.parsingResult!=null ) {
 			inputPanel.showTokenInfoUponMeta(editor, previewState, offset);
 		}
         else if ( mouseEvent.isAltDown() && previewState.parsingResult!=null ) {


### PR DESCRIPTION
Using the meta key was a bad idea because it doesn't exist on Windows. in addition, the control key already is mapped to jump from a token to its definition.  Now I'm using the control key for both platforms and you should use the control key to view token information. Fixes #181