### PR TITLE
Split a wall of text in readme into items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,25 @@ An [IntelliJ](https://www.jetbrains.com/idea/) 12.1.x, 13.x plugin for ANTLR v4 
 
 [Plugin page at intellij](http://plugins.jetbrains.com/plugin/7358?pr=idea)
 
-This plugin is for ANTLR v4 grammars. Features: syntax highlighting,
-syntax error checking, semantic error checking, navigation window,
-goto-declaration, find usages, rename tokens, rename rules.
-Generates code; shortcut (ctrl-shift-G / meta-shift-G) but it's in Tools menu
-and popups.
-Code completion for tokens, rule names. finds tokenVocab option for code gen
-if there is a tokenVocab option, don't warn about implicit tokens.
-shortcut conflicted with grammar-kit plugin. Has live grammar interpreter
-for grammar preview. Right click on rule and say "Test ANTLR Rule".
-Changes to grammar seen in parse tree upon save of grammar. Works with
-Intellij 13.x and requires 12.1.x.
+This plugin is for ANTLR v4 grammars. 
+
+Features: 
+
+- syntax highlighting;
+- syntax error checking;
+- semantic error checking;
+- navigation window;
+- goto-declaration;
+- find usages;
+- rename tokens;
+- rename rules;
+- generates code; 
+- shortcut (ctrl-shift-G / meta-shift-G) but it's in Tools menu and popups.
+- code completion for tokens, rule names;
+- finds tokenVocab option for code gen if there is a tokenVocab option, don't warn about implicit tokens.
+- shortcut conflicted with grammar-kit plugin; 
+- has live grammar interpreter for grammar preview. Right click on rule and say "Test ANTLR Rule".
+- changes to grammar seen in parse tree upon save of grammar. Works with Intellij 13.x and requires 12.1.x.
 
 You can configure the ANTLR tool options per grammar file; right-click
 in a grammar or on a grammar element within the structured view.


### PR DESCRIPTION
Illustrates #192. I think text in the beginning of readme would benefit from splitting into items. Right now it looks like a wall of text. This same text is shown inside IntelliJ in plugins settings, and it is quite hard to read without proper splitting.