### PR TITLE
Fixed build errors in EAP 15

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -75,7 +75,7 @@ For really big files and
   </change-notes>
 
   <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="133"/> <!-- now requires 13.x, 14.x -->
+  <idea-version since-build="142.3050"/> <!-- now requires 13.x, 14.x -->
 
   <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->

--- a/src/java/org/antlr/intellij/plugin/actions/TestRuleAction.java
+++ b/src/java/org/antlr/intellij/plugin/actions/TestRuleAction.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.actions.EditorActionUtil;
+import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.util.Condition;
@@ -16,7 +16,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.refactoring.actions.BaseRefactoringAction;
 import org.antlr.intellij.plugin.ANTLRv4PluginController;
 import org.antlr.intellij.plugin.psi.ParserRuleRefNode;
 import org.antlr.intellij.plugin.psi.ParserRuleSpecNode;
@@ -100,13 +99,8 @@ public class TestRuleAction extends AnAction implements DumbAware {
 		}
 
 		PsiElement selectedPsiRuleNode;
-		final Integer offset = editor.getUserData(EditorActionUtil.EXPECTED_CARET_OFFSET);
-		if (offset != null) {
-			selectedPsiRuleNode = file.findElementAt(offset);
-		}
-		else {
-			selectedPsiRuleNode = BaseRefactoringAction.getElementAtCaret(editor, file);
-		}
+		final int offset = ((EditorEx) editor).getExpectedCaretOffset();
+		selectedPsiRuleNode = file.findElementAt(offset);
 //		System.out.println("sel el: "+selectedPsiRuleNode);
 
 ////		System.out.println("caret offset = "+editor.getCaretModel().getOffset());

--- a/src/java/org/antlr/intellij/plugin/preview/InputPanel.java
+++ b/src/java/org/antlr/intellij/plugin/preview/InputPanel.java
@@ -127,8 +127,8 @@ public class InputPanel {
 				TextComponentAccessor.TEXT_FIELD_WHOLE_TEXT
 			) {
 				@Override
-				protected void onFileChoosen(VirtualFile chosenFile) {
-					super.onFileChoosen(chosenFile);
+				protected void onFileChosen(VirtualFile chosenFile) {
+					super.onFileChosen(chosenFile);
 					// get state for grammar in current editor, not editor where user is typing preview input!
 //					ANTLRv4PluginController controller = ANTLRv4PluginController.getInstance(previewPanel.project);
 //					PreviewState previewState = controller.getPreviewState(chosenFile);


### PR DESCRIPTION
This fixes build errors in the current EAP version of IntelliJ 15 (142.3050). Unfortunately they introduced changes that are non backward compatible. `EXPECTED_CARET_OFFSET` could be handled with reflection, but I don't see how the two other changes could be handled this way.
I guess you'll have to maintain a separate branch for IntelliJ 15+, in which you'll want to modify `plugin.xml` to set a higher `since-build` value. This way, you can still release two versions of the plugin targeting different versions of IntelliJ.
This fixed #197, I was able to use the preview tool without any errors.