### PR TITLE
New preview panel based on a JTree

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -56,3 +56,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/02/07, jasonnn, Jason Markham, jasonmarkham@gmail.com
 2015/03/26, alekum, Alexey Kuzmenko, rojaster@yandex.ru(1ikb3zz@gmail.com)
 2015/07/30, maccimo, Maxim Degtyarev, mdegtyarev@gmail.com
+2015/08/12, bjansen, Bastien Jansen, bastien.jansen@gmx.com

--- a/src/java/org/antlr/intellij/plugin/preview/JTreeViewer.java
+++ b/src/java/org/antlr/intellij/plugin/preview/JTreeViewer.java
@@ -1,0 +1,214 @@
+package org.antlr.intellij.plugin.preview;
+
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.ui.components.JBScrollPane;
+import org.antlr.intellij.plugin.Icons;
+import org.antlr.v4.gui.TreeTextProvider;
+import org.antlr.v4.gui.TreeViewer;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.antlr.v4.runtime.tree.Tree;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.tree.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+
+import static com.intellij.icons.AllIcons.Actions.Find;
+import static com.intellij.icons.AllIcons.General.AutoscrollFromSource;
+import static org.antlr.intellij.plugin.ANTLRv4PluginController.PREVIEW_WINDOW_ID;
+
+public class JTreeViewer extends JPanel {
+
+    public boolean scrollFromSource = false;
+    public boolean highlightSource = false;
+    private PreviewPanel previewPanel;
+
+    private JTree myTree = new com.intellij.ui.treeStructure.Tree();
+    private TreeTextProvider treeTextProvider;
+
+    public JTreeViewer(Tree tree, PreviewPanel previewPanel) {
+        this.previewPanel = previewPanel;
+
+        setupComponents();
+        setupTree(tree);
+
+        myTree.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1) {
+                    onClick(e);
+                }
+            }
+        });
+    }
+
+    private void setupComponents() {
+        setLayout(new BorderLayout(0, 0));
+
+        JScrollPane scrollPane = new JBScrollPane(myTree);
+        ToggleAction scrollFromSourceBtn = new ToggleAction("Scroll from source", null, AutoscrollFromSource) {
+            @Override
+            public boolean isSelected(AnActionEvent e) {
+                return scrollFromSource;
+            }
+
+            @Override
+            public void setSelected(AnActionEvent e, boolean state) {
+                scrollFromSource = state;
+            }
+        };
+        ToggleAction scrollToSourceBtn = new ToggleAction("Highlight source", null, Find) {
+            @Override
+            public boolean isSelected(AnActionEvent e) {
+                return highlightSource;
+            }
+
+            @Override
+            public void setSelected(AnActionEvent e, boolean state) {
+                highlightSource = state;
+            }
+        };
+
+        DefaultActionGroup actionGroup = new DefaultActionGroup(
+                scrollFromSourceBtn,
+                scrollToSourceBtn
+        );
+        ActionToolbar bar = ActionManager.getInstance().createActionToolbar(PREVIEW_WINDOW_ID, actionGroup, true);
+
+        add(bar.getComponent(), BorderLayout.NORTH);
+        add(scrollPane, BorderLayout.CENTER);
+    }
+
+    private void setupTree(Tree tree) {
+        setTree(tree);
+
+        DefaultTreeCellRenderer renderer = new DefaultTreeCellRenderer();
+        renderer.setOpenIcon(Icons.PARSER_RULE);
+        renderer.setClosedIcon(Icons.PARSER_RULE);
+        renderer.setLeafIcon(Icons.LEXER_RULE);
+        myTree.setCellRenderer(renderer);
+    }
+
+    public void setTree(Tree tree) {
+        myTree.setModel(new DefaultTreeModel(wrap(tree), false));
+    }
+
+    public void setRuleNames(List<String> ruleNames) {
+        treeTextProvider = new TreeViewer.DefaultTreeTextProvider(ruleNames);
+    }
+
+    public void setTreeTextProvider(TreeTextProvider treeTextProvider) {
+        this.treeTextProvider = treeTextProvider;
+    }
+
+    private MutableTreeNode wrap(final Tree tree) {
+        if (tree == null) {
+            return null;
+        }
+        DefaultMutableTreeNode root = new DefaultMutableTreeNode(tree) {
+            @Override
+            public String toString() {
+                String name = treeTextProvider.getText((Tree) getUserObject());
+
+                if (tree instanceof TerminalNode) {
+                    return name.equals("<EOF>") ? name : "\"" + name + "\"";
+                }
+
+                return name;
+            }
+
+
+        };
+
+        for (int i = 0; i < tree.getChildCount(); i++) {
+            root.add(wrap(tree.getChild(i)));
+        }
+        return root;
+    }
+
+    public void selectNodeAtOffset(int offset) {
+        if (!scrollFromSource) {
+            return;
+        }
+        DefaultMutableTreeNode root = (DefaultMutableTreeNode) myTree.getModel().getRoot();
+        Tree tree = (Tree) root.getUserObject();
+
+        if (tree instanceof ParseTree) {
+            DefaultMutableTreeNode atOffset = getNodeAtOffset(root, offset);
+
+            if (atOffset != null) {
+                TreePath path = new TreePath(atOffset.getPath());
+                myTree.getSelectionModel().setSelectionPath(path);
+                myTree.scrollPathToVisible(path);
+            }
+        }
+    }
+
+    @Nullable
+    private DefaultMutableTreeNode getNodeAtOffset(DefaultMutableTreeNode node, int offset) {
+        Tree tree = (Tree) node.getUserObject();
+
+        if (tree instanceof ParserRuleContext) {
+            ParserRuleContext ctx = (ParserRuleContext) tree;
+
+            if (inBounds(ctx, offset)) {
+                for (int i = 0; i < node.getChildCount(); i++) {
+                    DefaultMutableTreeNode child = (DefaultMutableTreeNode) node.getChildAt(i);
+                    DefaultMutableTreeNode atOffset = getNodeAtOffset(child, offset);
+
+                    if (atOffset != null) {
+                        return atOffset;
+                    }
+                }
+                // None of the children match, so it must be this node
+                return node;
+            }
+        } else if (tree instanceof TerminalNode) {
+            TerminalNode terminal = (TerminalNode) tree;
+
+            if (terminal.getSymbol().getStartIndex() <= offset && terminal.getSymbol().getStopIndex() >= offset) {
+                return node;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean inBounds(ParserRuleContext ctx, int offset) {
+        return ctx.getStart().getStartIndex() <= offset && ctx.getStop().getStopIndex() >= offset;
+    }
+
+    private void onClick(MouseEvent e) {
+        if (highlightSource) {
+            TreePath path = myTree.getClosestPathForLocation(e.getX(), e.getY());
+            if (path == null) {
+                return;
+            }
+            DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
+            Tree tree = (Tree) node.getUserObject();
+
+            int startIndex;
+            int stopIndex;
+
+            if (tree instanceof ParserRuleContext) {
+                startIndex = ((ParserRuleContext) tree).getStart().getStartIndex();
+                stopIndex = ((ParserRuleContext) tree).getStop().getStopIndex();
+            } else if (tree instanceof TerminalNode) {
+                startIndex = ((TerminalNode) tree).getSymbol().getStartIndex();
+                stopIndex = ((TerminalNode) tree).getSymbol().getStopIndex();
+            } else {
+                return;
+            }
+
+            Editor editor = previewPanel.inputPanel.getEditor(null);
+            editor.getSelectionModel().removeSelection();
+            editor.getSelectionModel().setSelection(startIndex, stopIndex + 1);
+        }
+    }
+}

--- a/src/java/org/antlr/intellij/plugin/preview/PreviewEditorMouseListener.java
+++ b/src/java/org/antlr/intellij/plugin/preview/PreviewEditorMouseListener.java
@@ -48,6 +48,9 @@ class PreviewEditorMouseListener implements EditorMouseListener, EditorMouseMoti
 		else if ( mouseEvent.isAltDown() ) {
 			inputPanel.setCursorToGrammarRule(e.getEditor().getProject(), inputPanel.previewState, offset);
 		}
+		else {
+			inputPanel.previewPanel.jTreeViewer.selectNodeAtOffset(offset);
+		}
 		inputPanel.clearGrammarHighlighters();
 	}
 

--- a/src/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
+++ b/src/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
@@ -53,6 +53,7 @@ public class PreviewPanel extends JPanel {
 	public InputPanel inputPanel;
 
 	public UberTreeViewer treeViewer;
+	public JTreeViewer jTreeViewer;
 	public ParseTree lastTree;
 
 	public ProfilerPanel profilerPanel;
@@ -89,7 +90,10 @@ public class PreviewPanel extends JPanel {
 		LOG.info("createParseTreePanel" + " " + project.getName());
 		Pair<UberTreeViewer, JPanel> pair = createParseTreePanel();
 		treeViewer = pair.a;
-		tabbedPane.addTab("Parse tree", pair.b);
+		tabbedPane.addTab("Parse graph", pair.b);
+
+		jTreeViewer = new JTreeViewer(null, this);
+		tabbedPane.addTab("Parse tree", jTreeViewer);
 
 		profilerPanel = new ProfilerPanel(project, this);
 		tabbedPane.addTab("Profiler", profilerPanel.$$$getRootComponent$$$());
@@ -252,12 +256,17 @@ public class PreviewPanel extends JPanel {
 			public void run() {
 				lastTree = result.tree;
 				if (result.parser instanceof PreviewParser) {
-					treeViewer.setTreeTextProvider(new AltLabelTextProvider(result.parser, preview.g));
+					AltLabelTextProvider provider = new AltLabelTextProvider(result.parser, preview.g);
+					treeViewer.setTreeTextProvider(provider);
 					treeViewer.setTree(result.tree);
+					jTreeViewer.setTreeTextProvider(provider);
+					jTreeViewer.setTree(result.tree);
 				}
 				else {
 					treeViewer.setRuleNames(Arrays.asList(preview.g.getRuleNames()));
 					treeViewer.setTree(result.tree);
+					jTreeViewer.setRuleNames(Arrays.asList(preview.g.getRuleNames()));
+					jTreeViewer.setTree(result.tree);
 				}
 			}
 		});


### PR DESCRIPTION
While the current "Parse tree" preview panel is a nice way to have a visual representation of what's parsed, it has several drawbacks:

- the bigger the sample text is, the slower it is to scroll the graph
- it doesn't provide a fast way to identify which node/leaf corresponds to a given portion of the sample text
- it doesn't provide a fast way to identify which portion of the sample text corresponds to a given node/leaf

This PR adds a third panel to the preview tool window, showing a JTree, combined with two buttons that allow:

- navigating from the text to the corresponding node/leaf in the tree
- highlighting the corresponding text when a node/leaf is selected in the tree

This is a panel very similar to the one provided by [PsiViewer](https://plugins.jetbrains.com/plugin/227).

Here's how it looks in action:

![image](https://cloud.githubusercontent.com/assets/281528/9220412/c13da8a8-40e2-11e5-8cc6-b1ecc454a5e6.png)
