### PR TITLE
Update the definition for ID (rid live-template) Fixes #248

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -57,3 +57,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/03/26, alekum, Alexey Kuzmenko, rojaster@yandex.ru(1ikb3zz@gmail.com)
 2015/07/30, maccimo, Maxim Degtyarev, mdegtyarev@gmail.com
 2015/08/12, bjansen, Bastien Jansen, bastien.jansen@gmx.com
+2016/01/08, jwhiting, James Whiting, james.whiting@gmail.com

--- a/resources/liveTemplates/lexer/user.xml
+++ b/resources/liveTemplates/lexer/user.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="user">
 
-	<template name="rid" value="$NAME$ : [a-zA-Z_]* [a-zA-Z0-9_]+ ;" description="Create identifier rule" toReformat="false" toShortenFQNames="true">
+	<template name="rid" value="$NAME$ : [a-zA-Z_]+ [a-zA-Z0-9_]* ;" description="Create identifier rule" toReformat="false" toShortenFQNames="true">
 		<variable name="NAME" expression="" defaultValue="&quot;ID&quot;" alwaysStopAt="true" />
 		<context>
 			<option name="ANTLR_OUTSIDE" value="true" />


### PR DESCRIPTION
Swapped * and + so that identifier starting with 0-9 is not accepted.