### PR TITLE
Fix tree visualisation for nodes without labels

### DIFF
--- a/src/java/org/antlr/intellij/plugin/preview/AltLabelTextProvider.java
+++ b/src/java/org/antlr/intellij/plugin/preview/AltLabelTextProvider.java
@@ -46,7 +46,12 @@ public class AltLabelTextProvider implements TreeTextProvider {
 			String[] altLabels = getAltLabels(r);
 			String name = r.name;
 			if ( altLabels!=null ) {
-				return name +":"+altLabels[inode.getOuterAltNum()];
+				int index = inode.getOuterAltNum();
+				if (index < altLabels.length) {
+					return name + ":" + altLabels[index];
+				} else {
+					return name;
+				}
 			}
 			else if ( r.getOriginalNumberOfAlts()>1 ) {
 				return name + ":" + inode.getOuterAltNum();


### PR DESCRIPTION
When testing an expression tree visualisation fails with
ArrayIndexOutOfBoundsException when generating node name. This should be
handled and node name should be used when no labels are available.
