### PR TITLE
Avoid storing code gen settings in workspace.xml, use misc.xml instead (fixes #289)

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -158,5 +158,6 @@ For really big files and slow grammars, there is an appreciable delay when displ
 	  <defaultLiveTemplatesProvider implementation="org.antlr.intellij.plugin.templates.ANTLRLiveTemplatesProvider"/>
 	  <liveTemplateContext implementation="org.antlr.intellij.plugin.templates.ANTLRGenericContext"/>
 	  <liveTemplateContext implementation="org.antlr.intellij.plugin.templates.OutsideRuleContext"/>
+	  <projectService serviceImplementation="org.antlr.intellij.plugin.configdialogs.ANTLRGenerationSettingsComponent"/>
   </extensions>
 </idea-plugin>

--- a/src/java/org/antlr/intellij/plugin/actions/GenerateParserAction.java
+++ b/src/java/org/antlr/intellij/plugin/actions/GenerateParserAction.java
@@ -68,10 +68,7 @@ public class GenerateParserAction extends AnAction implements DumbAware {
 									  forceGeneration);
 
 		boolean autogen =
-			ConfigANTLRPerGrammar.getBooleanProp(project,
-												 grammarFile.getPath(),
-												 ConfigANTLRPerGrammar.PROP_AUTO_GEN,
-												 false);
+			ConfigANTLRPerGrammar.getSettings(project, grammarFile.getPath()).autoGen;
 		if ( !unsaved || (unsaved && !autogen) ) {
 			// if everything already saved (not stale) then run ANTLR
 			// if had to be saved and autogen NOT on, then run ANTLR

--- a/src/java/org/antlr/intellij/plugin/configdialogs/ANTLRGenerationSettings.java
+++ b/src/java/org/antlr/intellij/plugin/configdialogs/ANTLRGenerationSettings.java
@@ -1,0 +1,27 @@
+package org.antlr.intellij.plugin.configdialogs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Stores settings related to code generation per grammar file.
+ */
+public class ANTLRGenerationSettings {
+	@SuppressWarnings("WeakerAccess")
+	public List<PerGrammarGenerationSettings> perGrammarGenerationSettings
+			= new ArrayList<PerGrammarGenerationSettings>();
+
+	public PerGrammarGenerationSettings findSettingsForFile(String fileName) {
+		for (PerGrammarGenerationSettings settings : perGrammarGenerationSettings) {
+			if (settings.fileName.equals(fileName)) {
+				return settings;
+			}
+		}
+
+		PerGrammarGenerationSettings settings = new PerGrammarGenerationSettings();
+		settings.fileName = fileName;
+		perGrammarGenerationSettings.add(settings);
+
+		return settings;
+	}
+}

--- a/src/java/org/antlr/intellij/plugin/configdialogs/ANTLRGenerationSettingsComponent.java
+++ b/src/java/org/antlr/intellij/plugin/configdialogs/ANTLRGenerationSettingsComponent.java
@@ -1,0 +1,33 @@
+package org.antlr.intellij.plugin.configdialogs;
+
+import com.intellij.openapi.components.*;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Stores code generation preferences in <code>.idea/misc.xml</code>.
+ */
+@State(name = "ANTLRGenerationPreferences")
+public class ANTLRGenerationSettingsComponent implements PersistentStateComponent<ANTLRGenerationSettings> {
+
+	private ANTLRGenerationSettings mySettings = new ANTLRGenerationSettings();
+
+	public static ANTLRGenerationSettingsComponent getInstance(Project project) {
+		return ServiceManager.getService(project, ANTLRGenerationSettingsComponent.class);
+	}
+
+	public ANTLRGenerationSettings getSettings() {
+		return mySettings;
+	}
+
+	@Nullable
+	@Override
+	public ANTLRGenerationSettings getState() {
+		return mySettings;
+	}
+
+	@Override
+	public void loadState(ANTLRGenerationSettings state) {
+		mySettings = state;
+	}
+}

--- a/src/java/org/antlr/intellij/plugin/configdialogs/PerGrammarGenerationSettings.java
+++ b/src/java/org/antlr/intellij/plugin/configdialogs/PerGrammarGenerationSettings.java
@@ -1,0 +1,17 @@
+package org.antlr.intellij.plugin.configdialogs;
+
+/**
+ * Stores the code generation settings for a given grammar file.
+ */
+@SuppressWarnings("WeakerAccess")
+public class PerGrammarGenerationSettings {
+	public String fileName;
+	public boolean autoGen;
+	public String outputDir;
+	public String libDir;
+	public String encoding;
+	public String pkg;
+	public String language;
+	public boolean generateListener = true;
+	public boolean generateVisitor;
+}

--- a/src/java/org/antlr/intellij/plugin/parsing/ParsingUtils.java
+++ b/src/java/org/antlr/intellij/plugin/parsing/ParsingUtils.java
@@ -52,6 +52,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 public class ParsingUtils {
 	public static Grammar BAD_PARSER_GRAMMAR;
 	public static LexerGrammar BAD_LEXER_GRAMMAR;
@@ -397,7 +399,7 @@ public class ParsingUtils {
 
 	public static GrammarRootAST parseGrammar(Project project, Tool antlr, String grammarFileName) {
 		try {
-			String encoding = ConfigANTLRPerGrammar.getProp(project, grammarFileName, ConfigANTLRPerGrammar.PROP_ENCODING, "UTF-8");
+			String encoding = firstNonNull(ConfigANTLRPerGrammar.getSettings(project, grammarFileName).encoding, "UTF-8");
 			char[] grammarText = Utils.readFile(grammarFileName, encoding);
 			String grammarTextS = new String(grammarText).replaceAll("\\r", "");
 			ANTLRStringStream in = new ANTLRStringStream(grammarTextS);


### PR DESCRIPTION
#289 was bothering me too, so I decided to fix it :)

Code gen settings are now stored in `misc.xml`, and existing settings will be automatically migrated (and removed) from `workspace.xml` as soon as the 'Configure ANTLR...' dialog is shown on a given file.