### PR TITLE
Improved navigation to rules contained under lexical modes. 

### DIFF
--- a/src/java/org/antlr/intellij/plugin/ANTLRv4ASTFactory.java
+++ b/src/java/org/antlr/intellij/plugin/ANTLRv4ASTFactory.java
@@ -17,6 +17,7 @@ import org.antlr.intellij.plugin.psi.AtAction;
 import org.antlr.intellij.plugin.psi.GrammarSpecNode;
 import org.antlr.intellij.plugin.psi.LexerRuleRefNode;
 import org.antlr.intellij.plugin.psi.LexerRuleSpecNode;
+import org.antlr.intellij.plugin.psi.ModeSpecNode;
 import org.antlr.intellij.plugin.psi.ParserRuleRefNode;
 import org.antlr.intellij.plugin.psi.ParserRuleSpecNode;
 import org.antlr.intellij.plugin.psi.RulesNode;
@@ -32,6 +33,7 @@ public class ANTLRv4ASTFactory extends ASTFactory {
 		ruleElementTypeToPsiFactory.put(ANTLRv4TokenTypes.RULE_ELEMENT_TYPES.get(ANTLRv4Parser.RULE_parserRuleSpec), ParserRuleSpecNode.Factory.INSTANCE);
 		ruleElementTypeToPsiFactory.put(ANTLRv4TokenTypes.RULE_ELEMENT_TYPES.get(ANTLRv4Parser.RULE_lexerRule), LexerRuleSpecNode.Factory.INSTANCE);
 		ruleElementTypeToPsiFactory.put(ANTLRv4TokenTypes.RULE_ELEMENT_TYPES.get(ANTLRv4Parser.RULE_grammarSpec), GrammarSpecNode.Factory.INSTANCE);
+		ruleElementTypeToPsiFactory.put(ANTLRv4TokenTypes.RULE_ELEMENT_TYPES.get(ANTLRv4Parser.RULE_modeSpec), ModeSpecNode.Factory.INSTANCE);
 		ruleElementTypeToPsiFactory.put(ANTLRv4TokenTypes.RULE_ELEMENT_TYPES.get(ANTLRv4Parser.RULE_action), AtAction.Factory.INSTANCE);
 	}
 

--- a/src/java/org/antlr/intellij/plugin/ANTLRv4FindUsagesProvider.java
+++ b/src/java/org/antlr/intellij/plugin/ANTLRv4FindUsagesProvider.java
@@ -4,10 +4,7 @@ import com.intellij.lang.cacheBuilder.WordsScanner;
 import com.intellij.lang.findUsages.FindUsagesProvider;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
-import org.antlr.intellij.plugin.psi.LexerRuleRefNode;
-import org.antlr.intellij.plugin.psi.LexerRuleSpecNode;
-import org.antlr.intellij.plugin.psi.ParserRuleRefNode;
-import org.antlr.intellij.plugin.psi.ParserRuleSpecNode;
+import org.antlr.intellij.plugin.psi.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,8 +12,7 @@ public class ANTLRv4FindUsagesProvider implements FindUsagesProvider {
 	@Override
 	public boolean canFindUsagesFor(@NotNull PsiElement psiElement) {
 //		System.out.println("find usages for "+psiElement+": "+psiElement.getText());
-		return psiElement instanceof LexerRuleSpecNode ||
-			   psiElement instanceof ParserRuleSpecNode;
+		return psiElement instanceof RuleSpecNode;
 //		return psiElement instanceof PsiNamedElement;
 	}
 
@@ -55,6 +51,9 @@ public class ANTLRv4FindUsagesProvider implements FindUsagesProvider {
 		}
 		if (element instanceof LexerRuleSpecNode) {
 			return "lexer rule";
+		}
+		if (element instanceof ModeSpecNode) {
+			return "mode";
 		}
 		return "n/a";
 	}

--- a/src/java/org/antlr/intellij/plugin/psi/GrammarElementRef.java
+++ b/src/java/org/antlr/intellij/plugin/psi/GrammarElementRef.java
@@ -2,10 +2,10 @@ package org.antlr.intellij.plugin.psi;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiReferenceBase;
+import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
+import org.antlr.intellij.plugin.ANTLRv4FileRoot;
 import org.antlr.intellij.plugin.ANTLRv4TokenTypes;
 import org.antlr.intellij.plugin.parser.ANTLRv4Lexer;
 import org.jetbrains.annotations.NotNull;
@@ -13,8 +13,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
+/**
+ * A reference to a grammar element (parser rule, lexer rule or lexical mode).
+ */
 public class GrammarElementRef extends PsiReferenceBase<GrammarElementRefNode> {
-	String ruleName;
+
+	private String ruleName;
+
 	public GrammarElementRef(GrammarElementRefNode idNode, String ruleName) {
 		super(idNode, new TextRange(0, ruleName.length()));
 		this.ruleName = ruleName;
@@ -68,7 +73,30 @@ public class GrammarElementRef extends PsiReferenceBase<GrammarElementRefNode> {
 	@Nullable
 	@Override
 	public PsiElement resolve() {
-		return MyPsiUtils.findSpecNode(getElement(), ruleName);
+		GrammarSpecNode grammar = PsiTreeUtil.getContextOfType(getElement(), GrammarSpecNode.class);
+		PsiElement specNode = MyPsiUtils.findSpecNode(grammar, ruleName);
+
+		if (specNode != null) {
+			return specNode;
+		}
+
+		// Look for a lexer rule in the tokenVocab file if it exists
+		if (getElement() instanceof LexerRuleRefNode) {
+			String tokenVocab = MyPsiUtils.findTokenVocabIfAny((ANTLRv4FileRoot) getElement().getContainingFile());
+
+			if (tokenVocab != null) {
+				PsiDirectory parentDirectory = getElement().getContainingFile().getParent();
+				if (parentDirectory != null) {
+					PsiFile tokenVocabFile = parentDirectory.findFile(tokenVocab + ".g4");
+					if (tokenVocabFile instanceof ANTLRv4FileRoot) {
+						GrammarSpecNode lexerGrammar = PsiTreeUtil.findChildOfType(tokenVocabFile, GrammarSpecNode.class);
+						return MyPsiUtils.findSpecNode(lexerGrammar, ruleName);
+					}
+				}
+			}
+		}
+
+		return null;
 	}
 
 	@Override

--- a/src/java/org/antlr/intellij/plugin/psi/GrammarElementRef.java
+++ b/src/java/org/antlr/intellij/plugin/psi/GrammarElementRef.java
@@ -68,8 +68,7 @@ public class GrammarElementRef extends PsiReferenceBase<GrammarElementRefNode> {
 	@Nullable
 	@Override
 	public PsiElement resolve() {
-		// root of all rules is RulesNode node so jump up and scan for ruleName
-		return MyPsiUtils.findRuleSpecNodeAbove(getElement(), ruleName);
+		return MyPsiUtils.findSpecNode(getElement(), ruleName);
 	}
 
 	@Override

--- a/src/java/org/antlr/intellij/plugin/psi/ModeSpecNode.java
+++ b/src/java/org/antlr/intellij/plugin/psi/ModeSpecNode.java
@@ -1,0 +1,50 @@
+package org.antlr.intellij.plugin.psi;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.tree.IElementType;
+import org.antlr.intellij.adaptor.parser.PsiElementFactory;
+import org.antlr.intellij.plugin.ANTLRv4TokenTypes;
+import org.antlr.intellij.plugin.parser.ANTLRv4Lexer;
+import org.antlr.intellij.plugin.parser.ANTLRv4Parser;
+import org.jetbrains.annotations.NotNull;
+
+import static org.antlr.intellij.plugin.psi.MyPsiUtils.findFirstChildOfType;
+
+/**
+ * A node representing a lexical {@code mode} definition, and all its child rules.
+ *
+ * @implNote this is technically not a 'rule', but it has the same characteristics as a named rule so we
+ * can extend {@code RuleSpecNode}
+ */
+public class ModeSpecNode extends RuleSpecNode {
+
+    public ModeSpecNode(@NotNull ASTNode node) {
+        super(node);
+    }
+
+    @Override
+    public IElementType getRuleRefType() {
+        return ANTLRv4TokenTypes.TOKEN_ELEMENT_TYPES.get(ANTLRv4Lexer.TOKEN_REF);
+    }
+
+    @Override
+    public GrammarElementRefNode getId() {
+        PsiElement idNode = findFirstChildOfType(this, ANTLRv4TokenTypes.getRuleElementType(ANTLRv4Parser.RULE_id));
+
+        if (idNode != null) {
+            return (LexerRuleRefNode) idNode.getFirstChild();
+        }
+
+        return null;
+    }
+
+    public static class Factory implements PsiElementFactory {
+        public static Factory INSTANCE = new Factory();
+
+        @Override
+        public PsiElement createElement(ASTNode node) {
+            return new ModeSpecNode(node);
+        }
+    }
+}

--- a/src/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
+++ b/src/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
@@ -122,15 +122,13 @@ public class MyPsiUtils {
     }
 
 	/**
-	 * Finds the first {@link RuleSpecNode} or {@link ModeSpecNode} matching the {@code ruleName} referenced by
-	 * the given {@code reference}.
+	 * Finds the first {@link RuleSpecNode} or {@link ModeSpecNode} matching the {@code ruleName} defined in
+	 * the given {@code grammar}.
 	 *
 	 * Rule specs can be either children of the {@link RulesNode}, or under one of the {@code mode}s defined in
 	 * the grammar. This means we have to walk the whole grammar to find matching candidates.
 	 */
-	public static PsiElement findSpecNode(GrammarElementRefNode reference, final String ruleName) {
-		GrammarSpecNode rules = PsiTreeUtil.getContextOfType(reference, GrammarSpecNode.class);
-
+	public static PsiElement findSpecNode(GrammarSpecNode grammar, final String ruleName) {
 		PsiElementFilter definitionFilter = new PsiElementFilter() {
 			@Override
 			public boolean isAccepted(PsiElement element1) {
@@ -143,7 +141,7 @@ public class MyPsiUtils {
 			}
 		};
 
-		PsiElement[] ruleSpec = PsiTreeUtil.collectElements(rules, definitionFilter);
+		PsiElement[] ruleSpec = PsiTreeUtil.collectElements(grammar, definitionFilter);
 		if (ruleSpec.length > 0) {
 			return ruleSpec[0];
 		}

--- a/src/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
+++ b/src/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
@@ -121,23 +121,32 @@ public class MyPsiUtils {
         }
     }
 
-	public static PsiElement findRuleSpecNodeAbove(GrammarElementRefNode element, final String ruleName) {
-		RulesNode rules = PsiTreeUtil.getContextOfType(element, RulesNode.class);
-		return findRuleSpecNode(ruleName, rules);
-	}
+	/**
+	 * Finds the first {@link RuleSpecNode} or {@link ModeSpecNode} matching the {@code ruleName} referenced by
+	 * the given {@code reference}.
+	 *
+	 * Rule specs can be either children of the {@link RulesNode}, or under one of the {@code mode}s defined in
+	 * the grammar. This means we have to walk the whole grammar to find matching candidates.
+	 */
+	public static PsiElement findSpecNode(GrammarElementRefNode reference, final String ruleName) {
+		GrammarSpecNode rules = PsiTreeUtil.getContextOfType(reference, GrammarSpecNode.class);
 
-	public static PsiElement findRuleSpecNode(final String ruleName, RulesNode rules) {
-		PsiElementFilter defnode = new PsiElementFilter() {
+		PsiElementFilter definitionFilter = new PsiElementFilter() {
 			@Override
-			public boolean isAccepted(PsiElement element) {
-				PsiElement nameNode = element.getFirstChild();
-				if ( nameNode==null ) return false;
-				return (element instanceof ParserRuleSpecNode || element instanceof LexerRuleSpecNode) &&
-					   nameNode.getText().equals(ruleName);
+			public boolean isAccepted(PsiElement element1) {
+				if (!(element1 instanceof RuleSpecNode)) {
+					return false;
+				}
+
+				GrammarElementRefNode id = ((RuleSpecNode) element1).getId();
+				return id != null && id.getText().equals(ruleName);
 			}
 		};
-		PsiElement[] ruleSpec = PsiTreeUtil.collectElements(rules, defnode);
-		if ( ruleSpec.length>0 ) return ruleSpec[0];
+
+		PsiElement[] ruleSpec = PsiTreeUtil.collectElements(rules, definitionFilter);
+		if (ruleSpec.length > 0) {
+			return ruleSpec[0];
+		}
 		return null;
 	}
 


### PR DESCRIPTION
This PR improves navigation inside lexer grammars.

The current navigation algorithm was only looking for rules defined under the 'default' lexical mode (represented by the class `RulesNode`).

I modified that algorithm to look for rules in the whole grammar, which includes rules defined under user-defined lexical modes (which are not part of the `RulesNode`).

I also created a new `ModeSpecNode` class to make lexical modes instances of `PsiNamedElement`. This means that it's now possible to navigate to `mode FOO` from a call to `pushMode(FOO)`. This also means that 'find usages' works on lexical modes.

With these changes, it should now be possible to navigate to any (lexer) declaration, no matter where it is defined in the grammar.