### PR TITLE
docs(readme): update supported IntelliJ versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IntelliJ Idea Plugin for ANTLR v4 [![Build Travis-CI Status](https://travis-ci.org/antlr/intellij-plugin-v4.svg?branch=master)](https://travis-ci.org/antlr/intellij-plugin-v4) [![Latest version](https://img.shields.io/jetbrains/plugin/v/7358.svg?label=latest%20version)](https://plugins.jetbrains.com/plugin/7358) ![Downloads](https://img.shields.io/jetbrains/plugin/d/7358.svg)
 
-An [IntelliJ](https://www.jetbrains.com/idea/) 2016.2 .. 2019.3 plugin for ANTLR v4 ([plugin source at github](https://github.com/antlr/intellij-plugin-v4)).
+An [IntelliJ](https://www.jetbrains.com/idea/) 2018.3 .. 2020.1 plugin for ANTLR v4 ([plugin source at github](https://github.com/antlr/intellij-plugin-v4)).
 
 [Plugin page at intellij](http://plugins.jetbrains.com/plugin/7358?pr=idea)
 


### PR DESCRIPTION
Updates the supported IntelliJ versions in the readme.

To check the compatibility with a specific version add the following code to the `build.gradle` ([source](https://github.com/JetBrains/gradle-intellij-plugin/issues/385#issuecomment-634772312)):

```gradle
apply from:'https://raw.githubusercontent.com/FWDekker/intellij-randomness/master/gradle/scripts/verifier.gradle'

runPluginVerifier {
    pluginFileName = "antlr-intellij-plugin-v4-1.15-SNAPSHOT"
    ides = ["IC-2018.2"]
    verifierVersion = "1.241"
}
```

Could you also please update the heavily outdated project description to reflect the supported versions? It should be "An IntelliJ plugin for ANTLR v4 in IntelliJ 2018.3+" or something like this