### PR TITLE
Add ability to use the generated parser instead of the source grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ because the interpreter is language agnostic.
 For the same reasons, if your parser and/or lexer classes extend a custom implementation of the 
 base parser/lexer classes, your custom code will *not* be run during live preview. 
 
+As of 1.17, this limitation is partially not true. The configuration window of a grammar has a new option
+that allows using the generated parser code in the preview. In this case, the grammar must be compiled into
+a Java class (just to be on Project's target classpath). Any changes made to such grammar are not immediately
+reflected in the preview and the project must be recompiled instead.
+
 ## History
 
 See [Releases](https://github.com/antlr/intellij-plugin-v4/releases)

--- a/contributors.txt
+++ b/contributors.txt
@@ -63,3 +63,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/07/10, wojciszek, Wojciech Kruczkowski, kruczkowski.wojciech@gmail.com
 2019/11/24, nopeslide, Uffke Drechsler, nopeslide@web.de
 2020/12/05, roggenbrot, Sascha Dais, sdais@gmx.net
+2021/06/04, akovari, Adam Kovari, kovariadam@gmail.com

--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -58,6 +58,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.io.File;
+import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
@@ -414,47 +415,34 @@ public class ANTLRv4PluginController implements ProjectComponent {
             LexerGrammar lg = (LexerGrammar) grammars[0];
             Grammar g = grammars[1];
 
-            ANTLRv4GrammarProperties grammarProperties = ANTLRv4GrammarPropertiesStore.getGrammarProperties(project, grammarFile);
+			Constructor<Parser> parserCtor = null;
+			Constructor<Lexer> lexerCtor = null;
+
+			ANTLRv4GrammarProperties grammarProperties = ANTLRv4GrammarPropertiesStore.getGrammarProperties(project, grammarFile);
             if (grammarProperties.isUseGeneratedParserCodeCheckBox()) {
                 String parserClassName = grammarFile.getNameWithoutExtension();
                 String lexerClassName = lg.name;
 
-                Class<Parser> parserClass = null;
-                Class<Lexer> lexerClass = null;
+				try {
+					Class<?> tokenStreamClass = Class.forName(TokenStream.class.getName(), true, this.projectClassLoader);
+					Class<?> charStreamClass = Class.forName(CharStream.class.getName(), true, this.projectClassLoader);
 
-                Class<?> tokenStreamClass = null;
-                Class<?> charStreamClass = null;
+					Class<Parser> parserClass = (Class<Parser>) Class.forName(parserClassName, true, this.projectClassLoader);
+					Class<Lexer> lexerClass = (Class<Lexer>) Class.forName(lexerClassName, true, this.projectClassLoader);
 
-                try {
-                    tokenStreamClass = Class.forName(TokenStream.class.getName(), true, this.projectClassLoader);
-                    charStreamClass = Class.forName(CharStream.class.getName(), true, this.projectClassLoader);
-
-                    parserClass = (Class<Parser>) Class.forName(parserClassName, true, this.projectClassLoader);
-                    lexerClass = (Class<Lexer>) Class.forName(lexerClassName, true, this.projectClassLoader);
-                } catch (ClassNotFoundException e) {
-                    Messages.showErrorDialog(project, "Cannot find class '" + parserClassName + "'", CommonBundle.getErrorTitle());
-                }
-
-                try {
-                    synchronized (previewState) { // build atomically
-                        previewState.lg = lg;
-                        previewState.g = g;
-                        if (lexerClass != null) {
-                            previewState.lexerCtor = lexerClass.getDeclaredConstructor(charStreamClass);
-                        }
-                        if (parserClass != null) {
-                            previewState.parserCtor = parserClass.getDeclaredConstructor(tokenStreamClass);
-                        }
-                    }
-                } catch (NoSuchMethodException e) {
-                    e.printStackTrace();
-                }
-            } else {
-                synchronized (previewState) {
-                    previewState.lg = lg;
-                    previewState.g = g;
+					parserCtor = parserClass.getDeclaredConstructor(tokenStreamClass);
+					lexerCtor = lexerClass.getDeclaredConstructor(charStreamClass);
+                } catch (ClassNotFoundException | NoSuchMethodException e) {
+                    LOG.warn(e);
                 }
             }
+
+			synchronized (previewState) {
+				previewState.lg = lg;
+				previewState.g = g;
+				previewState.lexerCtor = lexerCtor;
+				previewState.parserCtor = parserCtor;
+			}
         }
         return grammarFileName;
     }

--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -1,5 +1,6 @@
 package org.antlr.intellij.plugin;
 
+import com.intellij.CommonBundle;
 import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.ui.ConsoleView;
@@ -23,8 +24,11 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.progress.util.BackgroundTaskUtil;
 import com.intellij.openapi.progress.util.ProgressWindow;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.OrderEnumerator;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileAdapter;
 import com.intellij.openapi.vfs.VirtualFileEvent;
@@ -34,22 +38,29 @@ import com.intellij.openapi.wm.ToolWindowAnchor;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
+import com.intellij.util.lang.UrlClassLoader;
 import com.intellij.util.messages.MessageBusConnection;
+import org.antlr.intellij.plugin.configdialogs.ANTLRv4GrammarProperties;
+import org.antlr.intellij.plugin.configdialogs.ANTLRv4GrammarPropertiesStore;
 import org.antlr.intellij.plugin.parsing.ParsingUtils;
 import org.antlr.intellij.plugin.parsing.RunANTLROnGrammarFile;
 import org.antlr.intellij.plugin.preview.PreviewPanel;
 import org.antlr.intellij.plugin.preview.PreviewState;
 import org.antlr.intellij.plugin.profiler.ProfilerPanel;
 import org.antlr.v4.parse.ANTLRParser;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
 
 /** This object is the controller for the ANTLR plug-in. It receives
  *  events and can send them on to its contained components. For example,
@@ -87,6 +98,7 @@ public class ANTLRv4PluginController implements ProjectComponent {
 	public MyFileEditorManagerAdapter myFileEditorManagerAdapter = new MyFileEditorManagerAdapter();
 
 	private ProgressIndicator parsingProgressIndicator;
+    private UrlClassLoader projectClassLoader;
 
 	public ANTLRv4PluginController(Project project) {
 		this.project = project;
@@ -119,6 +131,7 @@ public class ANTLRv4PluginController implements ProjectComponent {
 		// make sure the tool windows are created early
 		createToolWindows();
 		installListeners();
+        initClassLoader();
 	}
 
 	public void createToolWindows() {
@@ -191,7 +204,22 @@ public class ANTLRv4PluginController implements ProjectComponent {
 		return "antlr.ProjectComponent";
 	}
 
-	// ------------------------------
+    private void initClassLoader() {
+        List<String> compiledClassUrls = OrderEnumerator.orderEntries(project).runtimeOnly().classes().usingCache().getPathsList().getPathList();
+        final List<URL> urls = new ArrayList<>();
+
+        for (String path : compiledClassUrls) {
+            try {
+                urls.add(new File(FileUtil.toSystemIndependentName(path)).toURI().toURL());
+            } catch (MalformedURLException e1) {
+                LOG.error(e1);
+            }
+        }
+
+        this.projectClassLoader = UrlClassLoader.build().parent(TokenStream.class.getClassLoader()).urls(urls).get();
+    }
+
+    // ------------------------------
 
 	public void installListeners() {
 		LOG.info("installListeners "+project.getName());
@@ -378,18 +406,58 @@ public class ANTLRv4PluginController implements ProjectComponent {
 		}
 	}
 
-	private String updateGrammarObjectsFromFile_(VirtualFile grammarFile) {
-		String grammarFileName = grammarFile.getPath();
-		PreviewState previewState = getPreviewState(grammarFile);
-		Grammar[] grammars = ParsingUtils.loadGrammars(grammarFile, project);
-		if (grammars != null) {
-			synchronized (previewState) { // build atomically
-				previewState.lg = (LexerGrammar)grammars[0];
-				previewState.g = grammars[1];
-			}
-		}
-		return grammarFileName;
-	}
+    private String updateGrammarObjectsFromFile_(VirtualFile grammarFile) {
+        String grammarFileName = grammarFile.getPath();
+        PreviewState previewState = getPreviewState(grammarFile);
+        Grammar[] grammars = ParsingUtils.loadGrammars(grammarFile, project);
+        if (grammars != null) {
+            LexerGrammar lg = (LexerGrammar) grammars[0];
+            Grammar g = grammars[1];
+
+            ANTLRv4GrammarProperties grammarProperties = ANTLRv4GrammarPropertiesStore.getGrammarProperties(project, grammarFile);
+            if (grammarProperties.isUseGeneratedParserCodeCheckBox()) {
+                String parserClassName = grammarFile.getNameWithoutExtension();
+                String lexerClassName = lg.name;
+
+                Class<Parser> parserClass = null;
+                Class<Lexer> lexerClass = null;
+
+                Class<?> tokenStreamClass = null;
+                Class<?> charStreamClass = null;
+
+                try {
+                    tokenStreamClass = Class.forName(TokenStream.class.getName(), true, this.projectClassLoader);
+                    charStreamClass = Class.forName(CharStream.class.getName(), true, this.projectClassLoader);
+
+                    parserClass = (Class<Parser>) Class.forName(parserClassName, true, this.projectClassLoader);
+                    lexerClass = (Class<Lexer>) Class.forName(lexerClassName, true, this.projectClassLoader);
+                } catch (ClassNotFoundException e) {
+                    Messages.showErrorDialog(project, "Cannot find class '" + parserClassName + "'", CommonBundle.getErrorTitle());
+                }
+
+                try {
+                    synchronized (previewState) { // build atomically
+                        previewState.lg = lg;
+                        previewState.g = g;
+                        if (lexerClass != null) {
+                            previewState.lexerCtor = lexerClass.getDeclaredConstructor(charStreamClass);
+                        }
+                        if (parserClass != null) {
+                            previewState.parserCtor = parserClass.getDeclaredConstructor(tokenStreamClass);
+                        }
+                    }
+                } catch (NoSuchMethodException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                synchronized (previewState) {
+                    previewState.lg = lg;
+                    previewState.g = g;
+                }
+            }
+        }
+        return grammarFileName;
+    }
 
 	// TODO there could be multiple grammars importing/tokenVocab'ing this lexer grammar
 	public PreviewState getAssociatedParserIfLexer(String grammarFileName) {
@@ -434,10 +502,10 @@ public class ANTLRv4PluginController implements ProjectComponent {
 				(indicator) -> {
 					long start = System.nanoTime();
 
-					previewState.parsingResult = ParsingUtils.parseText(
-							previewState.g, previewState.lg, previewState.startRuleName,
-							grammarFile, inputText, project
-					);
+                    previewState.parsingResult = ParsingUtils.parseText(
+                            previewState.g, previewState.lg, previewState.lexerCtor, previewState.parserCtor,
+                            previewState.startRuleName, grammarFile, inputText, project
+                    );
 
 					return () -> previewPanel.onParsingCompleted(previewState, System.nanoTime() - start);
 				},

--- a/src/main/java/org/antlr/intellij/plugin/configdialogs/ANTLRv4GrammarProperties.java
+++ b/src/main/java/org/antlr/intellij/plugin/configdialogs/ANTLRv4GrammarProperties.java
@@ -57,6 +57,9 @@ public class ANTLRv4GrammarProperties implements Cloneable {
     @OptionTag(converter = CaseChangingStrategyConverter.class)
     CaseChangingStrategy caseChangingStrategy = CaseChangingStrategy.LEAVE_AS_IS;
 
+    @Property
+    boolean useGeneratedParserCodeCheckBox = false;
+
     public ANTLRv4GrammarProperties() {
     }
 
@@ -71,6 +74,7 @@ public class ANTLRv4GrammarProperties implements Cloneable {
         this.generateListener = source.generateListener;
         this.generateVisitor = source.generateVisitor;
         this.caseChangingStrategy = source.caseChangingStrategy;
+        this.useGeneratedParserCodeCheckBox = source.useGeneratedParserCodeCheckBox;
     }
 
     public boolean shouldAutoGenerateParser() {
@@ -103,6 +107,10 @@ public class ANTLRv4GrammarProperties implements Cloneable {
 
     public boolean shouldGenerateParseTreeVisitor() {
         return generateVisitor;
+    }
+
+    public boolean isUseGeneratedParserCodeCheckBox() {
+        return useGeneratedParserCodeCheckBox;
     }
 
     public CaseChangingStrategy getCaseChangingStrategy() {

--- a/src/main/java/org/antlr/intellij/plugin/configdialogs/ConfigANTLRDialogPanel.form
+++ b/src/main/java/org/antlr/intellij/plugin/configdialogs/ConfigANTLRDialogPanel.form
@@ -10,7 +10,7 @@
     <children>
       <component id="ae2b3" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Location of imported grammars"/>
@@ -18,7 +18,7 @@
       </component>
       <component id="3ead0" class="javax.swing.JLabel">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Grammar file encoding; e.g., euc-jp"/>
@@ -26,7 +26,7 @@
       </component>
       <component id="1cd51" class="javax.swing.JTextField" binding="fileEncodingField">
         <constraints>
-          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -34,7 +34,7 @@
       </component>
       <component id="de85f" class="javax.swing.JCheckBox" binding="generateParseTreeVisitorCheckBox" default-binding="true">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="generate parse tree visitor"/>
@@ -42,7 +42,7 @@
       </component>
       <component id="e1f62" class="javax.swing.JCheckBox" binding="generateParseTreeListenerCheckBox" default-binding="true">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -51,7 +51,7 @@
       </component>
       <component id="1adf7" class="javax.swing.JLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Package/namespace for the generated code"/>
@@ -59,7 +59,7 @@
       </component>
       <component id="701ae" class="javax.swing.JTextField" binding="packageField">
         <constraints>
-          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -67,7 +67,7 @@
       </component>
       <component id="f5283" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Output directory where all output is generated"/>
@@ -75,19 +75,19 @@
       </component>
       <component id="a65b1" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="outputDirField">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="df9a9" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="libDirField">
         <constraints>
-          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="79b55" class="javax.swing.JCheckBox" binding="autoGenerateParsersCheckBox">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Auto-generate parsers upon save"/>
@@ -95,7 +95,7 @@
       </component>
       <component id="64571" class="javax.swing.JLabel">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Language (e.g., Java, Python2, CSharp, ...)"/>
@@ -103,7 +103,7 @@
       </component>
       <component id="6c6d2" class="javax.swing.JTextField" binding="languageField">
         <constraints>
-          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -111,7 +111,7 @@
       </component>
       <component id="beca9" class="javax.swing.JLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Case transformation in the Preview window"/>
@@ -119,7 +119,7 @@
       </component>
       <component id="6093" class="javax.swing.JComboBox" binding="caseTransformation" custom-create="true">
         <constraints>
-          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>

--- a/src/main/java/org/antlr/intellij/plugin/configdialogs/ConfigANTLRDialogPanel.form
+++ b/src/main/java/org/antlr/intellij/plugin/configdialogs/ConfigANTLRDialogPanel.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.antlr.intellij.plugin.configdialogs.ConfigANTLRPerGrammar">
-  <grid id="27dc6" binding="dialogContents" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="dialogContents" layout-manager="GridLayoutManager" row-count="11" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="630" height="292"/>
+      <xy x="20" y="20" width="630" height="333"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="ae2b3" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Location of imported grammars"/>
@@ -18,7 +18,7 @@
       </component>
       <component id="3ead0" class="javax.swing.JLabel">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Grammar file encoding; e.g., euc-jp"/>
@@ -26,7 +26,7 @@
       </component>
       <component id="1cd51" class="javax.swing.JTextField" binding="fileEncodingField">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -34,7 +34,7 @@
       </component>
       <component id="de85f" class="javax.swing.JCheckBox" binding="generateParseTreeVisitorCheckBox" default-binding="true">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="generate parse tree visitor"/>
@@ -42,7 +42,7 @@
       </component>
       <component id="e1f62" class="javax.swing.JCheckBox" binding="generateParseTreeListenerCheckBox" default-binding="true">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -51,7 +51,7 @@
       </component>
       <component id="1adf7" class="javax.swing.JLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Package/namespace for the generated code"/>
@@ -59,7 +59,7 @@
       </component>
       <component id="701ae" class="javax.swing.JTextField" binding="packageField">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -67,7 +67,7 @@
       </component>
       <component id="f5283" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Output directory where all output is generated"/>
@@ -75,19 +75,19 @@
       </component>
       <component id="a65b1" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="outputDirField">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="df9a9" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="libDirField">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="79b55" class="javax.swing.JCheckBox" binding="autoGenerateParsersCheckBox">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Auto-generate parsers upon save"/>
@@ -95,7 +95,7 @@
       </component>
       <component id="64571" class="javax.swing.JLabel">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Language (e.g., Java, Python2, CSharp, ...)"/>
@@ -103,20 +103,15 @@
       </component>
       <component id="6c6d2" class="javax.swing.JTextField" binding="languageField">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
         <properties/>
       </component>
-      <vspacer id="39a11">
-        <constraints>
-          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
       <component id="beca9" class="javax.swing.JLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Case transformation in the Preview window"/>
@@ -124,10 +119,24 @@
       </component>
       <component id="6093" class="javax.swing.JComboBox" binding="caseTransformation" custom-create="true">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
+      <component id="8cd09" class="javax.swing.JCheckBox" binding="useGeneratedParserCodeCheckBox" default-binding="true">
+        <constraints>
+          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="use generated parser code instead of grammar definition"/>
+          <toolTipText value="Live editing of grammar does not work with this option enabled. Every change in the grammar requires the project to be rebuilt."/>
+        </properties>
+      </component>
+      <vspacer id="39a11">
+        <constraints>
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/src/main/java/org/antlr/intellij/plugin/configdialogs/ConfigANTLRPerGrammar.java
+++ b/src/main/java/org/antlr/intellij/plugin/configdialogs/ConfigANTLRPerGrammar.java
@@ -32,8 +32,9 @@ public class ConfigANTLRPerGrammar extends DialogWrapper {
 	protected JCheckBox autoGenerateParsersCheckBox;
 	protected JTextField languageField;
 	private JComboBox<CaseChangingStrategy> caseTransformation;
+    private JCheckBox useGeneratedParserCodeCheckBox;
 
-	private ConfigANTLRPerGrammar(final Project project) {
+    private ConfigANTLRPerGrammar(final Project project) {
 		super(project, false);
 	}
 
@@ -79,6 +80,7 @@ public class ConfigANTLRPerGrammar extends DialogWrapper {
 		caseTransformation.setSelectedItem(grammarProperties.getCaseChangingStrategy());
 		generateParseTreeListenerCheckBox.setSelected(grammarProperties.shouldGenerateParseTreeListener());
 		generateParseTreeVisitorCheckBox.setSelected(grammarProperties.shouldGenerateParseTreeVisitor());
+		useGeneratedParserCodeCheckBox.setSelected(grammarProperties.isUseGeneratedParserCodeCheckBox());
 	}
 
     public void saveValues(Project project, String qualFileName) {
@@ -93,6 +95,7 @@ public class ConfigANTLRPerGrammar extends DialogWrapper {
 		grammarProperties.caseChangingStrategy = getCaseChangingStrategy();
 		grammarProperties.generateListener = generateParseTreeListenerCheckBox.isSelected();
 		grammarProperties.generateVisitor = generateParseTreeVisitorCheckBox.isSelected();
+		grammarProperties.useGeneratedParserCodeCheckBox = useGeneratedParserCodeCheckBox.isSelected();
 	}
 
 	boolean isModified(ANTLRv4GrammarProperties originalProperties) {
@@ -139,6 +142,7 @@ public class ConfigANTLRPerGrammar extends DialogWrapper {
 		return "ConfigANTLRPerGrammar{" +
 				" generateParseTreeListenerCheckBox=" + generateParseTreeListenerCheckBox +
 				", generateParseTreeVisitorCheckBox=" + generateParseTreeVisitorCheckBox +
+				", useGeneratedParserCodeCheckBox=" + useGeneratedParserCodeCheckBox +
 				", packageField=" + packageField +
 				", outputDirField=" + outputDirField +
 				", libDirField=" + libDirField +

--- a/src/main/java/org/antlr/intellij/plugin/preview/PreviewState.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/PreviewState.java
@@ -5,8 +5,12 @@ import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.antlr.intellij.plugin.parsing.ParsingResult;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
+
+import java.lang.reflect.Constructor;
 
 /** Track everything associated with the state of the preview window.
  *  For each grammar, we need to track an InputPanel (with <= 2 editor objects)
@@ -32,6 +36,9 @@ public class PreviewState {
 	public VirtualFile inputFile; 	// save input file when switching grammars
 
 	public ParsingResult parsingResult;
+
+	public Constructor<Parser> parserCtor;
+	public Constructor<Lexer> lexerCtor;
 
 	/** The current input editor (inputEditor or fileEditor) for this grammar
 	 *  in InputPanel. This can be null when a PreviewState and InputPanel


### PR DESCRIPTION
These changes add a new option to the grammar configuration and make it possible to use the generated parser instead of the source grammar (known limitation currently).

It is not bulletproof and won't work in many cases (when Java is not the target language for example), but this can still be helpful in many situations. If there is no generated parser, the old way of using the source grammar is used as a fallback. This shouldn't really break anything working now, it is just a new option.

Please consider this addition and let me know if it needs additional work, or if it is simply against the philosophy of this plugin and cannot be merged.
