### PR TITLE
Add rule name to Simple/Expert Profiler Grid, optional build of tree/hierarchy

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -63,3 +63,5 @@ YYYY/MM/DD, github id, Full name, email
 2019/07/10, wojciszek, Wojciech Kruczkowski, kruczkowski.wojciech@gmail.com
 2019/11/24, nopeslide, Uffke Drechsler, nopeslide@web.de
 2020/12/05, roggenbrot, Sascha Dais, sdais@gmx.net
+2021/11/04, OleksiiKovalov, Oleksii Kovalov, Oleksii.Kovalov@outlook.com
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginVersion=1.17-SNAPSHOT
 # e.g. IC-2016.3.3, IU-2018.2.5 etc
 # For a list of possible values, refer to the section 'com.jetbrains.intellij.idea' at
 # https://www.jetbrains.com/intellij-repository/releases
-ideaVersion=IC-2017.1.6
+ideaVersion=IC-2021.1.3
 
 # The version of ANTLR v4 that will be used to generate the parser
 antlr4Version=4.9.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@ pluginVersion=1.17-SNAPSHOT
 # e.g. IC-2016.3.3, IU-2018.2.5 etc
 # For a list of possible values, refer to the section 'com.jetbrains.intellij.idea' at
 # https://www.jetbrains.com/intellij-repository/releases
-
 ideaVersion=IC-2019.1.3
 
 # The version of ANTLR v4 that will be used to generate the parser

--- a/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
@@ -147,7 +147,7 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 				highlightSource = state;
 			}
 		};
-		ToggleAction autoBuildTree = new ToggleAction("Build tree after parse",null,AllIcons.Toolwindows.ToolWindowHierarchy) {
+		ToggleAction autoBuildTree = new ToggleAction("Build parse tree after parse",null,AllIcons.Toolwindows.ToolWindowHierarchy) {
 			@Override
 			public boolean isSelected(@NotNull AnActionEvent e) {
 				return buildTree;

--- a/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
@@ -75,6 +75,8 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 
 	private boolean scrollFromSource = false;
 	private boolean highlightSource = false;
+	private boolean buildTree = true;
+	private boolean buildHierarchy = true;
 
 	private ActionToolbar buttonBar;
 	private final CancelParserAction cancelParserAction = new CancelParserAction();
@@ -145,12 +147,34 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 				highlightSource = state;
 			}
 		};
+		ToggleAction autoBuildTree = new ToggleAction("Build tree after parse",null,AllIcons.Toolwindows.ToolWindowHierarchy) {
+			@Override
+			public boolean isSelected(@NotNull AnActionEvent e) {
+				return buildTree;
+			}
+
+			@Override
+			public void setSelected(@NotNull AnActionEvent e, boolean state) { buildTree = state; }
+		};
+		ToggleAction autoBuildHier = new ToggleAction("Build hierarchy after parse",null,AllIcons.Actions.ShowAsTree) {
+			@Override
+			public boolean isSelected(@NotNull AnActionEvent e) {
+				return buildHierarchy;
+			}
+
+			@Override
+			public void setSelected(@NotNull AnActionEvent e, boolean state) {
+				buildHierarchy = state;
+			}
+		};
 
 		DefaultActionGroup actionGroup = new DefaultActionGroup(
 				refreshAction,
 				cancelParserAction,
 				scrollFromSourceBtn,
-				scrollToSourceBtn
+				scrollToSourceBtn,
+				autoBuildTree,
+				autoBuildHier
 		);
 
 		return ActionManager.getInstance().createActionToolbar(PREVIEW_WINDOW_ID, actionGroup, false);
@@ -342,22 +366,32 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 	}
 
 	private void updateTreeViewer(final PreviewState preview, final ParsingResult result) {
+
 		ApplicationManager.getApplication().invokeLater(() -> {
 			if (result.parser instanceof PreviewParser) {
 				AltLabelTextProvider provider = new AltLabelTextProvider(result.parser, preview.g);
-				treeViewer.setTreeTextProvider(provider);
-				treeViewer.setTree(result.tree);
-				hierarchyViewer.setTreeTextProvider(provider);
-				hierarchyViewer.setTree(result.tree);
+				if(buildTree) {
+					treeViewer.setTreeTextProvider(provider);
+					treeViewer.setTree(result.tree);
+				}
+				if(buildHierarchy) {
+					hierarchyViewer.setTreeTextProvider(provider);
+					hierarchyViewer.setTree(result.tree);
+				}
 				tokenStreamViewer.setParsingResult(result.parser);
 			}
 			else {
-				treeViewer.setRuleNames(Arrays.asList(preview.g.getRuleNames()));
-				treeViewer.setTree(result.tree);
-				hierarchyViewer.setRuleNames(Arrays.asList(preview.g.getRuleNames()));
-				hierarchyViewer.setTree(result.tree);
+				if(buildTree) {
+					treeViewer.setRuleNames(Arrays.asList(preview.g.getRuleNames()));
+					treeViewer.setTree(result.tree);
+				}
+				if(buildHierarchy) {
+					hierarchyViewer.setRuleNames(Arrays.asList(preview.g.getRuleNames()));
+					hierarchyViewer.setTree(result.tree);
+				}
 			}
 		});
+
 	}
 
 

--- a/src/main/java/org/antlr/intellij/plugin/profiler/ExpertProfilerTableDataModel.java
+++ b/src/main/java/org/antlr/intellij/plugin/profiler/ExpertProfilerTableDataModel.java
@@ -1,5 +1,6 @@
 package org.antlr.intellij.plugin.profiler;
 
+import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.atn.DecisionInfo;
 import org.antlr.v4.runtime.atn.ParseInfo;
 
@@ -38,9 +39,15 @@ public class ExpertProfilerTableDataModel extends ProfilerTableDataModel {
 
 	// microsecond decimal precision
 	private final NumberFormat milliUpToMicroFormatter = new DecimalFormat("#.###");
+	private final String[] ruleNamesByDecision ;
 
-    public ExpertProfilerTableDataModel(ParseInfo parseInfo) {
+    public ExpertProfilerTableDataModel(ParseInfo parseInfo, Parser parser) {
         this.parseInfo = parseInfo;
+		/*copying rule names to not hold ref to parser object*/
+		ruleNamesByDecision  = new String[parser.getATN().decisionToState.size()];
+		for(int i = 0; i < ruleNamesByDecision .length; i++) {
+			ruleNamesByDecision [i] = parser.getRuleNames()[parser.getATN().getDecisionState(i).ruleIndex];
+		}
         for (int i = 0; i < columnNames.length; i++) {
             nameToColumnMap.put(columnNames[i], i);
         }
@@ -66,7 +73,7 @@ public class ExpertProfilerTableDataModel extends ProfilerTableDataModel {
 		DecisionInfo decisionInfo = parseInfo.getDecisionInfo()[decision];
 		switch (col) { // laborious but more efficient than reflection
             case 0:
-                return decisionInfo.decision;
+				return  String.format("%s (%d)",ruleNamesByDecision [decision],decision);
             case 1:
                 return decisionInfo.invocations;
             case 2:

--- a/src/main/java/org/antlr/intellij/plugin/profiler/ProfilerPanel.java
+++ b/src/main/java/org/antlr/intellij/plugin/profiler/ProfilerPanel.java
@@ -136,7 +136,7 @@ public class ProfilerPanel {
 	public void updateTableModelPerExpertCheckBox(ParseInfo parseInfo,Parser parser) {
 		AbstractTableModel model;
 		if ( expertCheckBox.isSelected() ) {
-			model = new ExpertProfilerTableDataModel(parseInfo);
+			model = new ExpertProfilerTableDataModel(parseInfo,parser);
 		}
 		else {
 			model = new SimpleProfilerTableDataModel(parseInfo,parser);

--- a/src/main/java/org/antlr/intellij/plugin/profiler/ProfilerPanel.java
+++ b/src/main/java/org/antlr/intellij/plugin/profiler/ProfilerPanel.java
@@ -94,7 +94,7 @@ public class ProfilerPanel {
 		this.previewState = previewState;
 		Parser parser = previewState.parsingResult.parser;
 		ParseInfo parseInfo = parser.getParseInfo();
-		updateTableModelPerExpertCheckBox(parseInfo);
+		updateTableModelPerExpertCheckBox(parseInfo,parser);
 		double parseTimeMS = parseTime_ns/(1000.0*1000.0);
 		// microsecond decimal precision
 		NumberFormat formatter = new DecimalFormat("#.###");
@@ -133,13 +133,13 @@ public class ProfilerPanel {
 		                          );
 	}
 
-	public void updateTableModelPerExpertCheckBox(ParseInfo parseInfo) {
+	public void updateTableModelPerExpertCheckBox(ParseInfo parseInfo,Parser parser) {
 		AbstractTableModel model;
 		if ( expertCheckBox.isSelected() ) {
 			model = new ExpertProfilerTableDataModel(parseInfo);
 		}
 		else {
-			model = new SimpleProfilerTableDataModel(parseInfo);
+			model = new SimpleProfilerTableDataModel(parseInfo,parser);
 		}
 		profilerDataTable.setModel(model);
 		profilerDataTable.setRowSorter(new TableRowSorter<>(model));
@@ -326,7 +326,7 @@ public class ProfilerPanel {
 				return;
 			}
 			ParseInfo parseInfo = previewState.parsingResult.parser.getParseInfo();
-			updateTableModelPerExpertCheckBox(parseInfo);
+			updateTableModelPerExpertCheckBox(parseInfo,previewState.parsingResult.parser);
 		});
 		profilerDataTable = new JBTable() {
 			@Override

--- a/src/main/java/org/antlr/intellij/plugin/profiler/SimpleProfilerTableDataModel.java
+++ b/src/main/java/org/antlr/intellij/plugin/profiler/SimpleProfilerTableDataModel.java
@@ -10,14 +10,12 @@ import java.util.LinkedHashMap;
 
 public class SimpleProfilerTableDataModel extends ProfilerTableDataModel {
 	public ParseInfo parseInfo;
-	public Parser parser;
     public LinkedHashMap<String, Integer> nameToColumnMap = new LinkedHashMap<>();
     public static final String[] columnNames = {
 			"Rule","Invocations", "Time", "Total k", "Max k", "Ambiguities", "DFA cache miss"
     };
 
-    public static final String[] columnToolTips =
-	{
+    public static final String[] columnToolTips = {
 		"name of rule and decision no",
         "# decision invocations",
 		"Rough estimate of time (ms) spent in prediction",
@@ -27,16 +25,13 @@ public class SimpleProfilerTableDataModel extends ProfilerTableDataModel {
 		"# of non-DFA transitions during prediction (cache miss)"
     };
 
-	// microsecond decimal precision
-	private final NumberFormat milliUpToMicroFormatter = new DecimalFormat("#.###");
-
-	private String[] rule;
+	private final String[] ruleNamesByDecision ;
 	public SimpleProfilerTableDataModel(ParseInfo parseInfo,Parser parser) {
         this.parseInfo = parseInfo;
         /*copying rule names to not hold ref to parser object*/
-        rule = new String[parser.getATN().decisionToState.size()];
-        for(int i = 0; i < rule.length; i++) {
-			rule[i] = parser.getRuleNames()[parser.getATN().getDecisionState(i).ruleIndex];
+		ruleNamesByDecision  = new String[parser.getATN().decisionToState.size()];
+        for(int i = 0; i < ruleNamesByDecision .length; i++) {
+			ruleNamesByDecision [i] = parser.getRuleNames()[parser.getATN().getDecisionState(i).ruleIndex];
 		}
         for (int i = 0; i < columnNames.length; i++) {
             nameToColumnMap.put(columnNames[i], i);
@@ -63,12 +58,12 @@ public class SimpleProfilerTableDataModel extends ProfilerTableDataModel {
         int decision = row;
 		DecisionInfo decisionInfo = parseInfo.getDecisionInfo()[decision];
 		switch (col) { // laborious but more efficient than reflection
-			case 0: return  String.format("%s (%d)",rule[decision],decision);
+			case 0:
+				return  String.format("%s (%d)",ruleNamesByDecision [decision],decision);
             case 1:
 				return decisionInfo.invocations;
 			case 2:
-				return //milliUpToMicroFormatter.format(decisionInfo.timeInPrediction / (1000.0 * 1000.0));
-						decisionInfo.timeInPrediction/1000;
+				return decisionInfo.timeInPrediction/1000.;
 			case 3:
 				return decisionInfo.LL_TotalLook+decisionInfo.SLL_TotalLook;
 			case 4:

--- a/src/main/java/org/antlr/intellij/plugin/profiler/SimpleProfilerTableDataModel.java
+++ b/src/main/java/org/antlr/intellij/plugin/profiler/SimpleProfilerTableDataModel.java
@@ -63,7 +63,7 @@ public class SimpleProfilerTableDataModel extends ProfilerTableDataModel {
             case 1:
 				return decisionInfo.invocations;
 			case 2:
-				return decisionInfo.timeInPrediction/1000.;
+				return decisionInfo.timeInPrediction/(1000.0 * 1000.0);
 			case 3:
 				return decisionInfo.LL_TotalLook+decisionInfo.SLL_TotalLook;
 			case 4:

--- a/src/main/java/org/antlr/intellij/plugin/profiler/SimpleProfilerTableDataModel.java
+++ b/src/main/java/org/antlr/intellij/plugin/profiler/SimpleProfilerTableDataModel.java
@@ -18,7 +18,7 @@ public class SimpleProfilerTableDataModel extends ProfilerTableDataModel {
 
     public static final String[] columnToolTips =
 	{
-		"name of rule",
+		"name of rule and decision no",
         "# decision invocations",
 		"Rough estimate of time (ms) spent in prediction",
 		"Total lookahead symbols examined",
@@ -33,9 +33,9 @@ public class SimpleProfilerTableDataModel extends ProfilerTableDataModel {
 	private String[] rule;
 	public SimpleProfilerTableDataModel(ParseInfo parseInfo,Parser parser) {
         this.parseInfo = parseInfo;
+        /*copying rule names to not hold ref to parser object*/
         rule = new String[parser.getATN().decisionToState.size()];
-        for(int i=0;i<rule.length;i++)
-		{
+        for(int i = 0; i < rule.length; i++) {
 			rule[i] = parser.getRuleNames()[parser.getATN().getDecisionState(i).ruleIndex];
 		}
         for (int i = 0; i < columnNames.length; i++) {
@@ -63,7 +63,7 @@ public class SimpleProfilerTableDataModel extends ProfilerTableDataModel {
         int decision = row;
 		DecisionInfo decisionInfo = parseInfo.getDecisionInfo()[decision];
 		switch (col) { // laborious but more efficient than reflection
-			case 0: return  rule[decision];
+			case 0: return  String.format("%s (%d)",rule[decision],decision);
             case 1:
 				return decisionInfo.invocations;
 			case 2:


### PR DESCRIPTION
**What does this PR do?**
1. Adds rule name to "Simple Profiler Grid" and "Expert Profiler Grid"
2. timeInPrediction  column converted back to "long, in ms"
3. Added toggle action to turn on/off building of tree/hierarchy after parse

**Why?**
1. it is more clear & convenient to see the rule name (which corresponds to grammar non-literal rule) than numeric decision number.
2. Sorting on long column works in the right way, as opposed to sorting "number as string", when "10" comes right after "1"
3. Building a tree/hierarchy for big test scripts can take a bunch of time, so it is good to have an option to turn it off.

**How is it checked?**
1. Unit tests for plugin project still run OK
2. manually tested by parsing and viewing several scripts for real oracle grammar.

**Risk analysis**
This change isn't particularly risky. All existing tests still pass, and even if something were to go wrong, it would have a negligible impact on the plugin as a whole.
