### PR TITLE
Fix NPE upon empty input

### DIFF
--- a/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
@@ -453,9 +453,11 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 			updateTreeViewer(previewState, previewState.parsingResult);
 			profilerPanel.setProfilerData(previewState, duration);
 			inputPanel.showParseErrors(previewState.parsingResult.syntaxErrorListener.getSyntaxErrors());
-		} else if ( previewState.startRuleName==null ) {
+		}
+		else if ( previewState.startRuleName==null ) {
 			indicateNoStartRuleInParseTreePane();
-		} else {
+		}
+		else {
 			indicateInvalidGrammarInParseTreePane();
 		}
 	}
@@ -493,12 +495,19 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 		int stopIndex;
 
 		if ( tree instanceof ParserRuleContext ) {
-			startIndex = ((ParserRuleContext) tree).getStart().getStartIndex();
-			stopIndex = ((ParserRuleContext) tree).getStop().getStopIndex();
-		} else if ( tree instanceof TerminalNode ) {
+			Token start = ((ParserRuleContext) tree).getStart();
+			Token stop = ((ParserRuleContext) tree).getStop();
+			if ( start==null || stop==null ) { // stop can be null if start is EOF; nothing to show so return
+				return;
+			}
+			startIndex = start.getStartIndex();
+			stopIndex = stop.getStopIndex();
+		}
+		else if ( tree instanceof TerminalNode ) {
 			startIndex = ((TerminalNode) tree).getSymbol().getStartIndex();
 			stopIndex = ((TerminalNode) tree).getSymbol().getStopIndex();
-		} else {
+		}
+		else {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #494.  When root had no input, hierarchy view of tree just saw EOF and got NPE looking for stop token.