### PR TITLE
Implement in-place rename

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -64,4 +64,3 @@ YYYY/MM/DD, github id, Full name, email
 2019/11/24, nopeslide, Uffke Drechsler, nopeslide@web.de
 2020/12/05, roggenbrot, Sascha Dais, sdais@gmx.net
 2021/11/04, OleksiiKovalov, Oleksii Kovalov, Oleksii.Kovalov@outlook.com
-

--- a/contributors.txt
+++ b/contributors.txt
@@ -64,3 +64,4 @@ YYYY/MM/DD, github id, Full name, email
 2019/11/24, nopeslide, Uffke Drechsler, nopeslide@web.de
 2020/12/05, roggenbrot, Sascha Dais, sdais@gmx.net
 2021/11/04, OleksiiKovalov, Oleksii Kovalov, Oleksii.Kovalov@outlook.com
+

--- a/src/main/java/org/antlr/intellij/plugin/refactor/ANTLRv4RefactoringSupport.java
+++ b/src/main/java/org/antlr/intellij/plugin/refactor/ANTLRv4RefactoringSupport.java
@@ -1,0 +1,20 @@
+package org.antlr.intellij.plugin.refactor;
+
+import com.intellij.lang.refactoring.RefactoringSupportProvider;
+import com.intellij.psi.PsiElement;
+import org.antlr.intellij.plugin.ANTLRv4Language;
+import org.antlr.intellij.plugin.psi.RuleSpecNode;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ANTLRv4RefactoringSupport extends RefactoringSupportProvider{
+	
+	public boolean isAvailable(@NotNull PsiElement context){
+		return context.getLanguage().isKindOf(ANTLRv4Language.INSTANCE);
+	}
+	
+	// variable in-place rename only applies to elements limited to one file
+	public boolean isMemberInplaceRenameAvailable(@NotNull PsiElement element, @Nullable PsiElement context){
+		return element instanceof RuleSpecNode;
+	}
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -169,5 +169,6 @@ For really big files and slow grammars, there is an appreciable delay when displ
                            displayName="ANTLR v4 default project settings"
                            instance="org.antlr.intellij.plugin.configdialogs.ANTLRv4ProjectSettings"/>
       <projectService serviceImplementation="org.antlr.intellij.plugin.configdialogs.ANTLRv4GrammarPropertiesComponent"/>
+      <lang.refactoringSupport language="ANTLRv4" implementationClass="org.antlr.intellij.plugin.refactor.ANTLRv4RefactoringSupport"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
Adds support for renaming spec nodes (rules, tokens, fragments) in-place, without opening the rename dialog.

This doesn't modify renaming logic in any way; it just enables the in-place UI, since it works without modification, even for elements used in multiple files.

Note that references to rules between files can cause false-positive "rule not found" warnings/errors, but that happens independently of this PR, even when renaming rules by hand - jump to declaration still works correctly for these rules, though. Renaming elements only used in the same file doesn't cause issues.