### PR TITLE
Avoid closing preview panel when file switching

### DIFF
--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -278,11 +278,9 @@ public class ANTLRv4PluginController implements ProjectComponent {
 		}
 		if ( newFile.getName().endsWith(".g") ) {
 			LOG.info("currentEditorFileChangedEvent ANTLR 4 cannot handle .g files, only .g4");
-			hidePreview();
 			return;
 		}
 		if ( !newFile.getName().endsWith(".g4") ) {
-			hidePreview();
 			return;
 		}
 

--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -278,6 +278,7 @@ public class ANTLRv4PluginController implements ProjectComponent {
 		}
 		if ( newFile.getName().endsWith(".g") ) {
 			LOG.info("currentEditorFileChangedEvent ANTLR 4 cannot handle .g files, only .g4");
+			hidePreview();
 			return;
 		}
 		if ( !newFile.getName().endsWith(".g4") ) {


### PR DESCRIPTION
When we switch files with ANTLR4 preview panel, it's closed.
Now with this commit, we never close preview panel.
Each grammar have his preview conserved.
I keep it very simple (only remove hide previews calls), say me if we need more complex logic.

Resolve https://github.com/antlr/intellij-plugin-v4/issues/409