### PR TITLE
Fixes #539. "null" appeared in tree for literals

### DIFF
--- a/src/main/java/org/antlr/intellij/plugin/preview/AltLabelTextProvider.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/AltLabelTextProvider.java
@@ -74,6 +74,13 @@ public class AltLabelTextProvider implements TreeTextProvider {
 			return text;
 		}
 
-		return parser.getVocabulary().getSymbolicName(token.getType()) + ": \"" + text + "\"";
+		String symbolicName = parser.getVocabulary().getSymbolicName(token.getType());
+		if ( symbolicName==null ) { // it's a literal like ';' or 'return'
+			return text;
+		}
+		if ( text.toUpperCase().equals(symbolicName) ) { // IMPORT:import
+			return symbolicName;
+		}
+		return symbolicName + ":" + text;
 	}
 }


### PR DESCRIPTION
Signed-off-by: Terence Parr <parrt@antlr.org>

* I removed quotes so we see `ID:abc` not `ID:"abc"` which is shorter.
* `X:x` -> `X`