### PR TITLE
Automatically choose first rule in grammar as start rule

### DIFF
--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -16,7 +16,10 @@ import com.intellij.openapi.editor.event.EditorFactoryEvent;
 import com.intellij.openapi.editor.event.EditorMouseAdapter;
 import com.intellij.openapi.editor.event.EditorMouseEvent;
 import com.intellij.openapi.extensions.PluginId;
-import com.intellij.openapi.fileEditor.*;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
@@ -242,7 +245,7 @@ public class ANTLRv4PluginController implements ProjectComponent {
 	}
 
 	/** The test ANTLR rule action triggers this event. This can occur
-	 *  only occur when the current editor the showing a grammar, because
+	 *  only occur when the current editor is showing a grammar, because
 	 *  that is the only time that the action is enabled. We will see
 	 *  a file changed event when the project loads the first grammar file.
 	 */

--- a/src/main/java/org/antlr/intellij/plugin/preview/PreviewEditorMouseListener.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/PreviewEditorMouseListener.java
@@ -55,8 +55,7 @@ class PreviewEditorMouseListener implements EditorMouseListener, EditorMouseMoti
 		InputPanel.clearDecisionEventHighlighters(editor);
 	}
 
-	public void rightClick(final PreviewState previewState, Editor editor, int offset)
-	{
+	public void rightClick(final PreviewState previewState, Editor editor, int offset) {
 		if (previewState.parsingResult == null) return;
 		final List<RangeHighlighter> highlightersAtOffset = MyActionUtils.getRangeHighlightersAtOffset(editor, offset);
 		if (highlightersAtOffset.size() == 0) {
@@ -80,7 +79,7 @@ class PreviewEditorMouseListener implements EditorMouseListener, EditorMouseMoti
 	}
 
 	@Override
-	public void mouseMoved(EditorMouseEvent e){
+	public void mouseMoved(EditorMouseEvent e) {
 		int offset = getEditorCharOffsetAndRemoveTokenHighlighters(e);
 		if ( offset<0 ) return;
 

--- a/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
@@ -21,6 +21,7 @@ import org.antlr.intellij.plugin.parsing.ParsingResult;
 import org.antlr.intellij.plugin.parsing.ParsingUtils;
 import org.antlr.intellij.plugin.parsing.PreviewParser;
 import org.antlr.intellij.plugin.profiler.ProfilerPanel;
+import org.antlr.v4.misc.OrderedHashMap;
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -314,6 +315,15 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 		LOG.info("switchToGrammar " + grammarFileName+" "+project.getName());
 		ANTLRv4PluginController controller = ANTLRv4PluginController.getInstance(project);
 		PreviewState previewState = controller.getPreviewState(grammarFile);
+
+		// From 1.18, automatically set the start rule name to the first rule in the grammar
+		// if none has been specified
+		if ( previewState.g!=null && previewState.startRuleName==null ) {
+			OrderedHashMap<String, Rule> rules = previewState.g.rules;
+			if (rules != null && rules.size() > 0) {
+				previewState.startRuleName = rules.getElement(0).name;
+			}
+		}
 
 		inputPanel.switchToGrammar(previewState, grammarFile);
 		profilerPanel.switchToGrammar(previewState, grammarFile);


### PR DESCRIPTION
Fixes #460 so we automatically choose first rule in grammar as start rule but can still set to other rules.

Signed-off-by: Terence Parr <parrt@antlr.org>
