### PR TITLE
[WIP] Parse and tree view refresh in background

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,3 +65,7 @@ test {
         exceptionFormat "full"
     }
 }
+
+runIde {
+    jvmArgs '-Xmx8G'
+}

--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -445,11 +445,12 @@ public class ANTLRv4PluginController implements ProjectComponent {
 		parsingProgressIndicator = BackgroundTaskUtil.executeAndTryWait(
 				(indicator) -> {
 					long start = System.nanoTime();
-
+					System.out.println("PARSE START "+Thread.currentThread().getName());
 					previewState.parsingResult = ParsingUtils.parseText(
 							previewState.g, previewState.lg, previewState.startRuleName,
 							grammarFile, inputText, project
 					);
+					System.out.println("PARSE STOP "+Thread.currentThread().getName());
 
 					return () -> previewPanel.onParsingCompleted(previewState, System.nanoTime() - start);
 				},

--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -436,9 +436,6 @@ public class ANTLRv4PluginController implements ProjectComponent {
 	}
 
 	public void parseText(final VirtualFile grammarFile, String inputText) {
-		// Wipes out the console and also any error annotations
-		previewPanel.inputPanel.clearParseErrors();
-
 		final PreviewState previewState = getPreviewState(grammarFile);
 
 		// Parse text in a background thread so we can cancel parsing if grammar is badly written

--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -441,10 +441,10 @@ public class ANTLRv4PluginController implements ProjectComponent {
 
 		final PreviewState previewState = getPreviewState(grammarFile);
 
-		abortCurrentParsing();
-
-		// Parse text in a background thread to avoid freezing the UI if the grammar is badly written
-		// an takes ages to interpret the input.
+		// Parse text in a background thread so we can cancel parsing if grammar is badly written
+		// and takes ages to interpret the input.  This entire method executes as part of
+		// a MergingUpdateQueue so already executes in a thread but leaving existing mechanism
+		// as it's tied to the cancel operation.
 		parsingProgressIndicator = BackgroundTaskUtil.executeAndTryWait(
 				(indicator) -> {
 					long start = System.nanoTime();

--- a/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
+++ b/src/main/java/org/antlr/intellij/plugin/preview/PreviewPanel.java
@@ -463,6 +463,7 @@ public class PreviewPanel extends JPanel implements ParsingResultSelectionListen
 		updateQueue.queue(new Update(this) {
 			@Override
 			public void run() {
+				inputPanel.clearParseErrors(); // Wipe console and also any error annotations
 				controller.parseText(grammarFile, inputText);
 			}
 		});


### PR DESCRIPTION
Fixes #546.  Parsing / tree view is now updated with a queue that doesn't update parse tree in GUI thread nor on each key stroke.  @bjansen can you take a peek? In the end was simple to add.