### PR TITLE
Bugfix for issue: #569 Plugin doesn't reassign extension if it has already been associated with text

### DIFF
--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4PluginController.java
@@ -6,6 +6,7 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
@@ -20,6 +21,8 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.fileTypes.FileTypes;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
@@ -54,7 +57,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /** This object is the controller for the ANTLR plug-in. It receives
  *  events and can send them on to its contained components. For example,
@@ -113,6 +115,16 @@ public class ANTLRv4PluginController implements ProjectComponent {
 
 	@Override
 	public void initComponent() {
+
+		final FileTypeManager fileTypeManager = FileTypeManager.getInstance();
+		final String defaultExtension = ANTLRv4FileType.INSTANCE.getDefaultExtension();
+
+		WriteCommandAction.runWriteCommandAction(this.project, () ->
+				fileTypeManager.removeAssociatedExtension(FileTypes.PLAIN_TEXT, defaultExtension));
+
+		WriteCommandAction.runWriteCommandAction(this.project, () ->
+				fileTypeManager.associateExtension(ANTLRv4FileType.INSTANCE, defaultExtension));
+
 	}
 
 	@Override

--- a/src/test/java/org/antlr/intellij/plugin/TestUtils.java
+++ b/src/test/java/org/antlr/intellij/plugin/TestUtils.java
@@ -1,25 +1,33 @@
 package org.antlr.intellij.plugin;
 
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.util.ThrowableRunnable;
 import com.intellij.util.lang.CompoundRuntimeException;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 public class TestUtils {
+
+	public static void releaseEditorIfNotDisposed(Editor editor) {
+		if (!editor.isDisposed()) EditorFactory.getInstance().releaseEditor(editor);
+	}
+
 	public static void tearDownIgnoringObjectNotDisposedException(ThrowableRunnable<Exception> delegate) throws Exception {
 		try {
 			delegate.run();
 		} catch (RuntimeException e) {
 			// We don't want to release the editor in the Tool Output tool window, so we ignore
 			// ObjectNotDisposedExceptions related to this particular editor
-			if ( e.getClass().getName().equals("com.intellij.openapi.util.TraceableDisposable$ObjectNotDisposedException")
+			if ( e.getClass().getName().startsWith("com.intellij.openapi.util.TraceableDisposable$")
 					|| e instanceof CompoundRuntimeException ) {
 				StringWriter stringWriter = new StringWriter();
 				e.printStackTrace(new PrintWriter(stringWriter));
 				String stack = stringWriter.toString();
+				System.out.println(e.getStackTrace()[0].getClassName());
 				if ( stack.contains("ANTLRv4PluginController.createToolWindows") ||
-						stack.contains("Issue559Test") || stack.contains("Issue540Test") ||
+
+						stack.contains("Issue559") || stack.contains("Issue540") || stack.contains("Issue569") ||
 						stack.contains("org.antlr.intellij.plugin.preview.InputPanel.createPreviewEditor") ) {
 					return;
 				}

--- a/src/test/java/org/antlr/intellij/plugin/TestUtils.java
+++ b/src/test/java/org/antlr/intellij/plugin/TestUtils.java
@@ -18,8 +18,9 @@ public class TestUtils {
 				StringWriter stringWriter = new StringWriter();
 				e.printStackTrace(new PrintWriter(stringWriter));
 				String stack = stringWriter.toString();
-				if ( stack.contains("ANTLRv4PluginController.createToolWindows") || stack.contains("Issue559Test")
-						|| stack.contains("org.antlr.intellij.plugin.preview.InputPanel.createPreviewEditor") ) {
+				if ( stack.contains("ANTLRv4PluginController.createToolWindows") ||
+						stack.contains("Issue559Test") || stack.contains("Issue540Test") ||
+						stack.contains("org.antlr.intellij.plugin.preview.InputPanel.createPreviewEditor") ) {
 					return;
 				}
 			}

--- a/src/test/java/org/antlr/intellij/plugin/editor/Issue540Test.java
+++ b/src/test/java/org/antlr/intellij/plugin/editor/Issue540Test.java
@@ -3,7 +3,6 @@ package org.antlr.intellij.plugin.editor;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -91,8 +90,9 @@ public class Issue540Test extends BasePlatformTestCase {
         FileUtils.forceDeleteOnExit(LEXER_FILE);
         FileUtils.forceDeleteOnExit(PARSER_FILE);
         FileUtils.forceDeleteOnExit(new File(getTestDataGenPath()));
-        EditorFactory.getInstance().releaseEditor(myFixture.getEditor());
-        TestUtils.tearDownIgnoringObjectNotDisposedException(super::tearDown);
+        TestUtils.tearDownIgnoringObjectNotDisposedException(() -> {
+            super.tearDown();
+        });
     }
 
 }

--- a/src/test/java/org/antlr/intellij/plugin/editor/Issue540Test.java
+++ b/src/test/java/org/antlr/intellij/plugin/editor/Issue540Test.java
@@ -1,0 +1,98 @@
+package org.antlr.intellij.plugin.editor;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.testFramework.VfsTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.antlr.intellij.plugin.ANTLRv4PluginController;
+import org.antlr.intellij.plugin.TestUtils;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import java.io.File;
+
+public class Issue540Test extends BasePlatformTestCase {
+
+    private final File LEXER_FILE = new File(getTestDataPath()+"TestLexer.g4");
+    private final File PARSER_FILE = new File(getTestDataPath()+"TestParser.g4");
+    private final File TOKENS_FILE = new File(getTestDataGenPath()+"TestLexer.tokens");
+
+    @Test
+    public void test_shouldOnlyCreateTokensWhenModified() {
+
+        // Create files and controller
+        VirtualFile lexerFile = createAndOpenFile(LEXER_FILE, "lexer grammar TestLexer;\nTOKEN1: 'TOKEN1';");
+        VirtualFile parserFile = createAndOpenFile(PARSER_FILE, "parser grammar TestParser;\noptions {tokenVocab=TestLexer;}\nstartRule: TOKEN1;");
+        ANTLRv4PluginController controller = ANTLRv4PluginController.getInstance(getProject());
+
+        // No tokens should be created yet
+        assertFalse(TOKENS_FILE.exists());
+
+        // Add one token to file, switch to parser file and check that tokens were created
+        switchToFile(lexerFile);
+        addLineToCurrentFile("TOKEN2: 'TOKEN2';", lexerFile, controller);
+        switchToFile(parserFile);
+        assertTrue(TOKENS_FILE.exists());
+        long lastModified1 = TOKENS_FILE.lastModified();
+
+        // Switch to lexer file, add token, and check if tokens file was updated
+        switchToFile(lexerFile);
+        addLineToCurrentFile("TOKEN3: 'TOKEN3';", lexerFile, controller);
+        switchToFile(parserFile);
+        long lastModified2 = new File(TOKENS_FILE.getAbsolutePath()).lastModified();
+        assertTrue(lastModified2 > lastModified1);
+
+        // Switch back and forth again, and make sure tokens are not recreated
+        switchToFile(lexerFile);
+        switchToFile(parserFile);
+        assertEquals(lastModified2, TOKENS_FILE.lastModified());
+
+    }
+
+    private VirtualFile createAndOpenFile(File file, String contents) {
+        String absPath = file.getAbsolutePath();
+        VfsTestUtil.overwriteTestData(absPath, contents);
+        VirtualFile virtualFile = WriteAction.computeAndWait(() ->
+                LocalFileSystem.getInstance().refreshAndFindFileByPath(absPath));
+        myFixture.openFileInEditor(virtualFile);
+        return virtualFile;
+    }
+
+    private String getTestDataGenPath() {
+        return getTestDataPath() + "gen/";
+    }
+
+    private void addLineToCurrentFile(String line, VirtualFile file, ANTLRv4PluginController controller) {
+        ApplicationManager.getApplication().runWriteAction(() -> {
+            Document doc = myFixture.getEditor().getDocument();
+            doc.setText(doc.getText() + "\n" + line);
+            PsiDocumentManager.getInstance(getProject()).commitDocument(doc);
+            FileDocumentManager.getInstance().saveDocument(doc);
+            if (controller != null) controller.grammarFileSavedEvent(file);
+        });
+    }
+
+    private void switchToFile(VirtualFile vf) {
+        myFixture.openFileInEditor(vf);
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/";
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        FileUtils.forceDeleteOnExit(LEXER_FILE);
+        FileUtils.forceDeleteOnExit(PARSER_FILE);
+        FileUtils.forceDeleteOnExit(new File(getTestDataGenPath()));
+        EditorFactory.getInstance().releaseEditor(myFixture.getEditor());
+        TestUtils.tearDownIgnoringObjectNotDisposedException(super::tearDown);
+    }
+
+}

--- a/src/test/java/org/antlr/intellij/plugin/editor/Issue559Test.java
+++ b/src/test/java/org/antlr/intellij/plugin/editor/Issue559Test.java
@@ -1,6 +1,5 @@
 package org.antlr.intellij.plugin.editor;
 
-import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -52,7 +51,7 @@ public class Issue559Test extends BasePlatformTestCase {
     @Override
     protected void tearDown() throws Exception {
         TestUtils.tearDownIgnoringObjectNotDisposedException(() -> {
-            EditorFactory.getInstance().releaseEditor(myFixture.getEditor());
+            TestUtils.releaseEditorIfNotDisposed(myFixture.getEditor());
             super.tearDown();
         });
     }

--- a/src/test/java/org/antlr/intellij/plugin/editor/Issue569Test.java
+++ b/src/test/java/org/antlr/intellij/plugin/editor/Issue569Test.java
@@ -1,0 +1,50 @@
+package org.antlr.intellij.plugin.editor;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.fileTypes.FileTypes;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.antlr.intellij.plugin.ANTLRv4FileType;
+import org.antlr.intellij.plugin.ANTLRv4PluginController;
+import org.antlr.intellij.plugin.TestUtils;
+import org.junit.Test;
+
+public class Issue569Test extends BasePlatformTestCase {
+
+    @Test
+    public void test_shouldReassignExtensionType() {
+
+        // Reassign extension temporarily
+        WriteCommandAction.runWriteCommandAction(getProject(), () ->
+                FileTypeManager.getInstance().associateExtension(FileTypes.PLAIN_TEXT, "g4"));
+
+        // Test File
+        VirtualFile file = myFixture.configureByFile("FooParser.g4").getVirtualFile();
+        assertEquals(file.getFileType(), FileTypes.PLAIN_TEXT);
+
+        // Create controller and initialize it
+        ANTLRv4PluginController controller = ANTLRv4PluginController.getInstance(getProject());
+        assertNotNull(controller);
+        controller.initComponent();
+
+        // Check if file type is reassigned
+        assertEquals(file.getFileType(), ANTLRv4FileType.INSTANCE);
+
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/references";
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        TestUtils.tearDownIgnoringObjectNotDisposedException(() -> {
+            EditorFactory.getInstance().releaseEditor(myFixture.getEditor());
+            super.tearDown();
+        });
+    }
+
+}


### PR DESCRIPTION
@@ -1,5 +1,23 @@
<!--
Thank you for proposing a contribution to the ANTLR jetbrains plugin!

As of 1.18, we use the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous contributor's certificate of origin.)
-->

