### PR TITLE
Feature: Renaming lexer grammars (Issue #433)

### DIFF
--- a/src/main/java/org/antlr/intellij/plugin/ANTLRv4FileRoot.java
+++ b/src/main/java/org/antlr/intellij/plugin/ANTLRv4FileRoot.java
@@ -3,6 +3,8 @@ package org.antlr.intellij.plugin;
 import com.intellij.extapi.psi.PsiFileBase;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NotNull;
 
 public class ANTLRv4FileRoot extends PsiFileBase {
@@ -14,6 +16,16 @@ public class ANTLRv4FileRoot extends PsiFileBase {
     @Override
     public FileType getFileType() {
         return ANTLRv4FileType.INSTANCE;
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return super.getName().replace(".g4", "");
+    }
+
+    @Override
+    public PsiElement setName(@NotNull String name) throws IncorrectOperationException {
+        return super.setName(name.replace(".g4", "") + ".g4");
     }
 
     @Override

--- a/src/main/java/org/antlr/intellij/plugin/psi/GrammarElementRef.java
+++ b/src/main/java/org/antlr/intellij/plugin/psi/GrammarElementRef.java
@@ -60,6 +60,10 @@ public class GrammarElementRef extends PsiReferenceBase<GrammarElementRefNode> {
 			return importedFile;
 		}
 
+		if ( MyPsiUtils.isGrammarName(getElement())) {
+			return getElement().getContainingFile();
+		}
+
 		GrammarSpecNode grammar = PsiTreeUtil.getContextOfType(getElement(), GrammarSpecNode.class);
 		PsiElement specNode = MyPsiUtils.findSpecNode(grammar, ruleName);
 

--- a/src/main/java/org/antlr/intellij/plugin/psi/GrammarElementRefNode.java
+++ b/src/main/java/org/antlr/intellij/plugin/psi/GrammarElementRefNode.java
@@ -4,7 +4,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.tree.IElementType;
-import com.intellij.util.IncorrectOperationException;
+import org.antlr.intellij.plugin.ANTLRv4TokenTypes;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -24,8 +24,13 @@ public abstract class GrammarElementRefNode extends LeafPsiElement implements Ps
 	}
 
 	@Override
-	public PsiElement setName(@NotNull String name) throws IncorrectOperationException {
-		throw new IncorrectOperationException("Can't rename grammar reference identifier");
+	public PsiElement setName(@NotNull String newName) {
+		name = newName;
+		replace(MyPsiUtils.createLeafFromText(getProject(),
+				getContext(),
+				newName,
+				ANTLRv4TokenTypes.TOKEN_ELEMENT_TYPES.get(org.antlr.intellij.plugin.parser.ANTLRv4Lexer.TOKEN_REF)));
+		return this;
 	}
 
 	@Override

--- a/src/main/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
+++ b/src/main/java/org/antlr/intellij/plugin/psi/MyPsiUtils.java
@@ -17,6 +17,9 @@ import org.antlr.intellij.plugin.ANTLRv4Language;
 import org.antlr.intellij.plugin.ANTLRv4TokenTypes;
 import org.antlr.intellij.plugin.parser.ANTLRv4Parser;
 import org.jetbrains.annotations.Nullable;
+import static org.antlr.intellij.plugin.parser.ANTLRv4Parser.RULE_identifier;
+import static org.antlr.intellij.plugin.parser.ANTLRv4Parser.RULE_optionValue;
+import static org.antlr.intellij.plugin.parser.ANTLRv4Parser.RULE_grammarType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -186,6 +189,37 @@ public class MyPsiUtils {
 			}
 		}
 		return vocabName;
+	}
+
+	public static Boolean isGrammarName(PsiElement element) {
+
+		PsiElement parent = element.getParent();
+
+		if (parent == null || !isRuleType(parent, RULE_identifier)) return false;
+
+		if (parent.getParent() != null && isRuleType(parent.getParent(), RULE_optionValue)) {
+			return true;
+		}
+
+		if (parent.getPrevSibling() != null && parent.getPrevSibling().getPrevSibling() != null) {
+			return isRuleType(parent.getPrevSibling().getPrevSibling(), RULE_grammarType);
+		}
+
+		return false;
+
+	}
+
+	public static Boolean isGrammarNameVocabOption(PsiElement element) {
+		if (!isGrammarName(element)) return false;
+		PsiElement parent = element.getParent();
+		return (parent.getParent() != null && isRuleType(parent.getParent(), RULE_optionValue));
+	}
+
+	public static Boolean isRuleType(PsiElement element,int type){
+		return element
+				.getNode()
+				.getElementType()
+				.equals(ANTLRv4TokenTypes.getRuleElementType(type));
 	}
 
 	public static PsiElement findElement(PsiElement startNode, int offset) {

--- a/src/main/java/org/antlr/intellij/plugin/refactor/GrammarRenameInputValidator.java
+++ b/src/main/java/org/antlr/intellij/plugin/refactor/GrammarRenameInputValidator.java
@@ -1,0 +1,22 @@
+package org.antlr.intellij.plugin.refactor;
+
+import com.intellij.patterns.ElementPattern;
+import com.intellij.psi.PsiElement;
+import com.intellij.refactoring.rename.RenameInputValidator;
+import com.intellij.util.ProcessingContext;
+import org.antlr.intellij.plugin.ANTLRv4FileRoot;
+import org.jetbrains.annotations.NotNull;
+import static com.intellij.patterns.PlatformPatterns.psiElement;
+
+public class GrammarRenameInputValidator implements RenameInputValidator {
+
+    @Override
+    public @NotNull ElementPattern<? extends PsiElement> getPattern() {
+        return psiElement(ANTLRv4FileRoot.class);
+    }
+
+    @Override
+    public boolean isInputValid(@NotNull String newName, PsiElement element, ProcessingContext context) {
+        return !newName.contains(" ");
+    }
+}

--- a/src/main/java/org/antlr/intellij/plugin/refactor/RenameGrammarProcessor.java
+++ b/src/main/java/org/antlr/intellij/plugin/refactor/RenameGrammarProcessor.java
@@ -1,0 +1,79 @@
+package org.antlr.intellij.plugin.refactor;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.refactoring.listeners.RefactoringElementListener;
+import com.intellij.refactoring.rename.RenamePsiElementProcessor;
+import com.intellij.usageView.UsageInfo;
+import com.intellij.util.IncorrectOperationException;
+import org.antlr.intellij.plugin.ANTLRv4FileRoot;
+import org.antlr.intellij.plugin.psi.GrammarElementRefNode;
+import org.antlr.intellij.plugin.psi.MyPsiUtils;
+import org.antlr.intellij.plugin.resolve.TokenVocabResolver;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import java.io.IOException;
+
+public class RenameGrammarProcessor extends RenamePsiElementProcessor {
+
+    @Override
+    public boolean canProcessElement(@NotNull PsiElement psiElement) {
+        return (psiElement instanceof GrammarElementRefNode) ||
+               (psiElement instanceof ANTLRv4FileRoot);
+    }
+
+    @Override
+    public boolean isToSearchInComments(@NotNull PsiElement element) {
+        return false;
+    }
+
+    @Override
+    public boolean isToSearchForTextOccurrences(@NotNull PsiElement element) {
+        return false;
+    }
+
+    @Override
+    public void renameElement(@NotNull PsiElement element, @NotNull String newName, UsageInfo @NotNull [] usages, @Nullable RefactoringElementListener listener) throws IncorrectOperationException {
+
+        if (element instanceof ANTLRv4FileRoot) {
+            ANTLRv4FileRoot root = (ANTLRv4FileRoot) element;
+            String oldName = root.getName();
+            root.setName(newName);
+            ((PsiNamedElement) root.getChildren()[0].getChildren()[1].getFirstChild()).setName(newName);
+
+            // Rename the token-vocab file if found
+            VirtualFile tokenVocabFile = TokenVocabResolver.findRelativeTokenFile(oldName, root);
+            if (tokenVocabFile != null) {
+                try {
+                    tokenVocabFile.rename(this, newName + ".tokens");
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+        } else if (element instanceof GrammarElementRefNode &&
+                MyPsiUtils.isGrammarName(element) &&
+                !MyPsiUtils.isGrammarNameVocabOption(element)) {
+
+            GrammarElementRefNode node = (GrammarElementRefNode) element;
+            PsiFile file = node.getContainingFile();
+            String fileName = file.getName();
+            int dotIndex = fileName.lastIndexOf('.');
+            file.setName(dotIndex >= 0 ? newName + "." + fileName.substring(dotIndex + 1) : newName);
+            node.replaceWithText(newName);
+
+        } else {
+            super.renameElement(element, newName, usages, listener);
+        }
+
+        for (UsageInfo usage : usages) {
+            if (MyPsiUtils.isGrammarNameVocabOption(usage.getElement())) {
+                super.renameElement(element, newName, usages, listener);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/antlr/intellij/plugin/resolve/TokenVocabResolver.java
+++ b/src/main/java/org/antlr/intellij/plugin/resolve/TokenVocabResolver.java
@@ -1,6 +1,8 @@
 package org.antlr.intellij.plugin.resolve;
 
 import com.intellij.lang.ASTNode;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -89,4 +91,9 @@ public class TokenVocabResolver {
 
 		return null;
 	}
+
+	public static VirtualFile findRelativeTokenFile(String baseName, ANTLRv4FileRoot file) {
+		return VfsUtil.findRelativeFile(file.getVirtualFile().getParent(), baseName + ".tokens");
+	}
+
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -168,5 +168,7 @@ For really big files and slow grammars, there is an appreciable delay when displ
                            instance="org.antlr.intellij.plugin.configdialogs.ANTLRv4ProjectSettings"/>
       <projectService serviceImplementation="org.antlr.intellij.plugin.configdialogs.ANTLRv4GrammarPropertiesComponent"/>
       <lang.refactoringSupport language="ANTLRv4" implementationClass="org.antlr.intellij.plugin.refactor.ANTLRv4RefactoringSupport"/>
+      <renamePsiElementProcessor implementation="org.antlr.intellij.plugin.refactor.RenameGrammarProcessor"/>
+      <renameInputValidator implementation="org.antlr.intellij.plugin.refactor.GrammarRenameInputValidator"/>
   </extensions>
 </idea-plugin>

--- a/src/test/java/org/antlr/intellij/plugin/TestUtils.java
+++ b/src/test/java/org/antlr/intellij/plugin/TestUtils.java
@@ -13,13 +13,15 @@ public class TestUtils {
 		} catch (RuntimeException e) {
 			// We don't want to release the editor in the Tool Output tool window, so we ignore
 			// ObjectNotDisposedExceptions related to this particular editor
-			if ( e.getClass().getName().equals("com.intellij.openapi.util.TraceableDisposable$ObjectNotDisposedException")
+			if ( e.getClass().getName().startsWith("com.intellij.openapi.util.TraceableDisposable$")
 					|| e instanceof CompoundRuntimeException ) {
 				StringWriter stringWriter = new StringWriter();
 				e.printStackTrace(new PrintWriter(stringWriter));
 				String stack = stringWriter.toString();
-				if ( stack.contains("ANTLRv4PluginController.createToolWindows") || stack.contains("Issue559Test")
-						|| stack.contains("org.antlr.intellij.plugin.preview.InputPanel.createPreviewEditor") ) {
+				if ( stack.contains("ANTLRv4PluginController.createToolWindows") ||
+						stack.contains("GrammarRenameTest") ||
+						stack.contains("Issue559") || stack.contains("Issue540") || stack.contains("Issue569") ||
+						stack.contains("org.antlr.intellij.plugin.preview.InputPanel.createPreviewEditor") ) {
 					return;
 				}
 			}

--- a/src/test/java/org/antlr/intellij/plugin/psi/GrammarElementRefTest.java
+++ b/src/test/java/org/antlr/intellij/plugin/psi/GrammarElementRefTest.java
@@ -118,7 +118,7 @@ public class GrammarElementRefTest extends LightPlatformCodeInsightFixtureTestCa
 		assertResolvedMatches(LexerRuleSpecNode.class, element -> {
 			assertEquals("TOKEN1", element.getName());
 			assertEquals(66, element.getTextOffset());
-			assertEquals("FooLexer.g4", element.getContainingFile().getName());
+			assertEquals("FooLexer", element.getContainingFile().getName());
 		});
 
 		moveCaret(85);
@@ -131,7 +131,7 @@ public class GrammarElementRefTest extends LightPlatformCodeInsightFixtureTestCa
 		assertResolvedMatches(TokenSpecNode.class, element -> {
 			assertEquals("STRING", element.getName());
 			assertEquals(34, element.getTextOffset());
-			assertEquals("FooLexer.g4", element.getContainingFile().getName());
+			assertEquals("FooLexer", element.getContainingFile().getName());
 		});
 	}
 
@@ -139,21 +139,21 @@ public class GrammarElementRefTest extends LightPlatformCodeInsightFixtureTestCa
 		myFixture.configureByFiles("FooParser.g4", "FooLexer.g4");
 
 		moveCaret(55);
-		assertResolvedMatches(ANTLRv4FileRoot.class, file -> assertEquals("FooLexer.g4", file.getName()));
+		assertResolvedMatches(ANTLRv4FileRoot.class, file -> assertEquals("FooLexer", file.getName()));
 	}
 
 	public void testReferencesToTokenVocabFileString() {
 		myFixture.configureByFiles("FooParser2.g4", "FooLexer.g4");
 
 		moveCaret(55);
-		assertResolvedMatches(ANTLRv4FileRoot.class, file -> assertEquals("FooLexer.g4", file.getName()));
+		assertResolvedMatches(ANTLRv4FileRoot.class, file -> assertEquals("FooLexer", file.getName()));
 	}
 
 	public void testReferenceToImportedFile() {
 		myFixture.configureByFiles("importing.g4", "imported.g4");
 
 		moveCaret(35);
-		assertResolvedMatches(ANTLRv4FileRoot.class, file -> assertEquals("imported.g4", file.getName()));
+		assertResolvedMatches(ANTLRv4FileRoot.class, file -> assertEquals("imported", file.getName()));
 	}
 
 	public void testReferenceToRuleInImportedFile() {
@@ -165,13 +165,13 @@ public class GrammarElementRefTest extends LightPlatformCodeInsightFixtureTestCa
 		moveCaret(66);
 		assertResolvedMatches(LexerRuleSpecNode.class, node -> {
 			assertEquals("Bar", node.getName());
-			assertEquals("imported2.g4", node.getContainingFile().getName());
+			assertEquals("imported2", node.getContainingFile().getName());
 		});
 
 		moveCaret(80);
 		assertResolvedMatches(LexerRuleSpecNode.class, node -> {
 			assertEquals("Baz", node.getName());
-			assertEquals("imported3.g4", node.getContainingFile().getName());
+			assertEquals("imported3", node.getContainingFile().getName());
 		});
 	}
 

--- a/src/test/java/org/antlr/intellij/plugin/refactor/GrammarRenameTest.java
+++ b/src/test/java/org/antlr/intellij/plugin/refactor/GrammarRenameTest.java
@@ -1,0 +1,61 @@
+package org.antlr.intellij.plugin.refactor;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.antlr.intellij.plugin.TestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+public class GrammarRenameTest extends BasePlatformTestCase {
+
+    @Test
+    public void test_validateInput() {
+        GrammarRenameInputValidator validator = new GrammarRenameInputValidator();
+        assertTrue(validator.isInputValid("foo", null, null));
+        assertFalse(validator.isInputValid("f oo", null, null));
+    }
+
+    @Test
+    public void test_renameFromLexerGrammar() {
+        testFilePaths("RenameLexer.g4", "RenameLexer.tokens", "RenameParser.g4");
+    }
+
+    @Test
+    public void test_renameGrammarFiles() {
+        testFilePaths("RenameParser.g4", "RenameLexer.tokens", "RenameLexer.g4");
+    }
+
+    @Test
+    public void test_renameFromFile() {
+        myFixture.configureByFiles("RenameLexer.g4", "RenameLexer.tokens", "RenameParser.g4");
+
+        // Rename the file
+        WriteCommandAction.runWriteCommandAction(getProject(), () ->
+                myFixture.renameElement(myFixture.getFile(), "RenameLexer2"));
+
+        assertNotNull(myFixture.findFileInTempDir("RenameLexer2.tokens"));
+        myFixture.checkResultByFile("RenameLexer2.g4", "RenameLexer-after.g4", false);
+        myFixture.checkResultByFile("RenameParser.g4", "RenameParser-after.g4", false);
+
+    }
+
+    private void testFilePaths(String @NotNull ... filePaths) {
+        myFixture.configureByFiles(filePaths);
+        myFixture.renameElementAtCaret("RenameLexer2");
+        assertNotNull(myFixture.findFileInTempDir("RenameLexer2.tokens"));
+        assertNotNull(myFixture.findFileInTempDir("RenameLexer2.g4"));
+        myFixture.checkResultByFile("RenameParser.g4", "RenameParser-after.g4", false);
+        myFixture.checkResultByFile("RenameLexer2.g4", "RenameLexer-after.g4", false);
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/rename";
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        TestUtils.tearDownIgnoringObjectNotDisposedException(() -> super.tearDown());
+    }
+
+}

--- a/src/test/resources/rename/RenameLexer-after.g4
+++ b/src/test/resources/rename/RenameLexer-after.g4
@@ -1,0 +1,3 @@
+lexer grammar RenameLexer2;
+
+TOKEN1: 'TOKEN1';

--- a/src/test/resources/rename/RenameLexer.g4
+++ b/src/test/resources/rename/RenameLexer.g4
@@ -1,0 +1,3 @@
+lexer grammar RenameLexer<caret>;
+
+TOKEN1: 'TOKEN1';

--- a/src/test/resources/rename/RenameLexer.tokens
+++ b/src/test/resources/rename/RenameLexer.tokens
@@ -1,0 +1,2 @@
+TOKEN1=2
+'TOKEN1'=2

--- a/src/test/resources/rename/RenameParser-after.g4
+++ b/src/test/resources/rename/RenameParser-after.g4
@@ -1,0 +1,7 @@
+parser grammar RenameParser;
+
+options {
+    tokenVocab=RenameLexer2;
+}
+
+myrule: TOKEN1;

--- a/src/test/resources/rename/RenameParser.g4
+++ b/src/test/resources/rename/RenameParser.g4
@@ -1,0 +1,7 @@
+parser grammar RenameParser;
+
+options {
+    tokenVocab=RenameLexer<caret>;
+}
+
+myrule: TOKEN1;


### PR DESCRIPTION
Signed-off-by: Kjartan Olason <olasonk@gmail.com>

@@ -1,5 +1,23 @@
<!--
Thank you for proposing a contribution to the ANTLR jetbrains plugin!

As of 1.18, we use the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous contributor's certificate of origin.)
-->

